### PR TITLE
Optionally Enable "redis.googleapis.com" Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,29 @@ module "memorystore" {
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alternative_location_id | The alternative zone where the instance will be provisioned. | string | `` | no |
-| authorized_network | The name of the memorystore authorized network. | string | `` | no |
-| display_name | An arbitrary and optional user-provided name for the instance. | string | `` | no |
-| labels | The resource labels to represent user provided metadata. | string | `<map>` | no |
-| location_id | The zone where the instance will be provisioned. | string | `` | no |
-| memory_size_gb | Redis memory size in GiB. | string | - | yes |
+| alternative\_location\_id | The alternative zone where the instance will be provisioned. | string | `` | no |
+| authorized\_network | The name of the memorystore authorized network. | string | `` | no |
+| display\_name | An arbitrary and optional user-provided name for the instance. | string | `` | no |
+| enable\_apis | Enable required APIs for Cloud Memorystore. | string | `true` | no |
+| labels | The resource labels to represent user provided metadata. | map | `<map>` | no |
+| location\_id | The zone where the instance will be provisioned. | string | `` | no |
+| memory\_size\_gb | Redis memory size in GiB. | string | - | yes |
 | name | The ID of the instance or a fully qualified identifier for the instance. | string | - | yes |
 | project | The ID of the project in which the resource belongs to. | string | - | yes |
-| redis_version | The version of Redis software. | string | `` | no |
+| redis\_version | The version of Redis software. | string | `` | no |
 | region | The GCP region to use. | string | `` | no |
-| reserved_ip_range | The CIDR range of internal addresses that are reserved for this instance. | string | `` | no |
+| reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | string | `` | no |
 | tier | The service tier of the instance. | string | `STANDARD_HA` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| current_location_id | The current zone where the Redis endpoint is placed. |
+| current\_location\_id | The current zone where the Redis endpoint is placed. |
 | host | The IP address of the instance. |
 | id | The memorystore instance ID. |
 | region | The region the instance lives in. |

--- a/main.tf
+++ b/main.tf
@@ -31,4 +31,14 @@ resource "google_redis_instance" "default" {
   reserved_ip_range = "${var.reserved_ip_range}"
 
   labels = "${var.labels}"
+
+  depends_on = ["google_project_service.redis"]
+}
+
+resource "google_project_service" "redis" {
+
+  count = "${var.enable_apis ? 1 : 0}"
+
+  project = "${var.project}"
+  service = "redis.googleapis.com"
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,6 @@ resource "google_redis_instance" "default" {
 }
 
 resource "google_project_service" "redis" {
-
   count = "${var.enable_apis ? 1 : 0}"
 
   project = "${var.project}"

--- a/test/fixtures/minimal/README.md
+++ b/test/fixtures/minimal/README.md
@@ -4,31 +4,30 @@ This test with create a new redis instance.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_path | Path to service account key (usually credentials.json). | string | - | yes |
-| location_id | Zone to create test instance. | string | `us-east1-b` | no |
-| memory_size_gb | Memory size of test instance. | string | `1` | no |
+| credentials\_path | Path to service account key (usually credentials.json). | string | - | yes |
+| location\_id | Zone to create test instance. | string | `us-east1-b` | no |
+| memory\_size\_gb | Memory size of test instance. | string | `1` | no |
 | name | Name of redis instance. | string | `test-minimal` | no |
-| project_id | Google cloud project id to create redis instance. | string | - | yes |
+| project\_id | Google cloud project id to create redis instance. | string | - | yes |
 | region | Region to create test instance. | string | `us-east1` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| credentials_path |  |
-| location_id |  |
-| memory_size_gb |  |
-| name |  |
-| output_current_location_id |  |
-| output_host |  |
-| output_id |  |
-| output_region |  |
-| project_id |  |
-| region |  |
+| credentials\_path | - |
+| location\_id | - |
+| memory\_size\_gb | - |
+| name | - |
+| output\_current\_location\_id | - |
+| output\_host | - |
+| output\_id | - |
+| output\_region | - |
+| project\_id | - |
+| region | - |
 
 [^]: (autogen_docs_end)

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,8 @@ variable "labels" {
   description = "The resource labels to represent user provided metadata."
   default     = {}
 }
+
+variable "enable_apis" {
+  description = "Enable required APIs for Cloud Memorystore."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,5 +73,5 @@ variable "labels" {
 
 variable "enable_apis" {
   description = "Enable required APIs for Cloud Memorystore."
-  default     = true
+  default     = "true"
 }


### PR DESCRIPTION
Enables the "redis.googleapis.com" service on the targeted project if the `enable_apis` variable is `true`. Defaults to `true` with what we consider to be the most basic module use case in mind - a brand new project is targeted and service enablement is not already managed by other means.

Integration tests now pass successfully when targeting a new, pristine project. As previously or with `enable_apis` set to `false`, tests will fail run against a pristine project with `Error 403: Google Cloud Memorystore for Redis API has not been used in project <PROJECT_ID> before or it is disabled...`.