### PR TITLE
removal of enable_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ module "memorystore" {
 | authorized\_network | The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used. | string | `"null"` | no |
 | connect\_mode | The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING. | string | `"null"` | no |
 | display\_name | An arbitrary and optional user-provided name for the instance. | string | `"null"` | no |
-| enable\_apis | Flag for enabling redis.googleapis.com in your project | bool | `"true"` | no |
 | labels | The resource labels to represent user provided metadata. | map(string) | `"null"` | no |
 | location\_id | The zone where the instance will be provisioned. If not provided, the service will choose a zone for the instance. For STANDARD_HA tier, instances will be created across two zones for protection against zonal failures. If [alternativeLocationId] is also provided, it must be different from [locationId]. | string | `"null"` | no |
 | memory\_size\_gb | Redis memory size in GiB. Defaulted to 1 GiB | number | `"1"` | no |
@@ -50,6 +49,15 @@ module "memorystore" {
 | region | The region the instance lives in. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+### APIs
+
+A project with the following APIs enabled must be used to host the
+resources of this module:
+
+- Google Cloud Memorystore API: `redis.googleapis.com`
 
 ## File structure
 

--- a/examples/basic/memorystore.tf
+++ b/examples/basic/memorystore.tf
@@ -23,5 +23,4 @@ module "memorystore" {
   name           = "memorystore"
   project        = "memorystore"
   memory_size_gb = "1"
-  enable_apis    = "true"
 }

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@
  */
 
 resource "google_redis_instance" "default" {
+
   project        = var.project
   name           = var.name
   tier           = var.tier

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,6 @@
  */
 
 resource "google_redis_instance" "default" {
-  depends_on = [module.enable_apis]
-
   project        = var.project
   name           = var.name
   tier           = var.tier
@@ -34,16 +32,4 @@ resource "google_redis_instance" "default" {
   reserved_ip_range = var.reserved_ip_range
 
   labels = var.labels
-}
-
-module "enable_apis" {
-  source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "4.0.1"
-
-  project_id  = "${var.project}"
-  enable_apis = "${var.enable_apis}"
-
-  activate_apis = [
-    "redis.googleapis.com",
-  ]
 }

--- a/test/fixtures/minimal/main.tf
+++ b/test/fixtures/minimal/main.tf
@@ -22,7 +22,6 @@ module "memstore" {
   project     = var.project_id
   region      = var.region
   location_id = var.location_id
-  enable_apis = true
 
   memory_size_gb = var.memory_size_gb
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,12 +25,6 @@ variable "project" {
   type        = string
 }
 
-variable "enable_apis" {
-  description = "Flag for enabling redis.googleapis.com in your project"
-  type        = bool
-  default     = true
-}
-
 variable "name" {
   description = "The ID of the instance or a fully qualified identifier for the instance."
   type        = string


### PR DESCRIPTION
The following changes would require end users to enable the api before using this module, with the current approach it may happen that they might not have access to get, list or enable the apis where this module would fail. According to the best practices the API enablement must be taken care by Project Administrators during project creation phase or by a separate team.

The PR includes required prerequisite information in the Readme file.