### PR TITLE
feat: submodule for cloud memorystore (memcache)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,3 +32,15 @@ suites:
           backend: local
     provisioner:
       name: terraform
+  - name: "memcache"
+    driver:
+      name: "terraform"
+      command_timeout: 1800
+      root_module_directory: test/fixtures/memcache
+    verifier:
+      name: terraform
+      systems:
+        - name: memcache
+          backend: local
+    provisioner:
+      name: terraform

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.4.6
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.11.6
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.6'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.6'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.6'

--- a/examples/memcache/main.tf
+++ b/examples/memcache/main.tf
@@ -26,12 +26,11 @@ module "private-service-access" {
 }
 
 module "memcache" {
-  source            = "../../modules/memcache"
-  name              = var.name
-  project           = var.project
-  memory_size_mb    = var.memory_size_mb
-  enable_apis       = var.enable_apis
-  cpu_count         = var.cpu_count
-  region            = var.region
-  module_depends_on = [module.private-service-access.peering_completed]
+  source         = "../../modules/memcache"
+  name           = var.name
+  project        = can(module.private-service-access.peering_completed) ? var.project : ""
+  memory_size_mb = var.memory_size_mb
+  enable_apis    = var.enable_apis
+  cpu_count      = var.cpu_count
+  region         = var.region
 }

--- a/examples/memcache/main.tf
+++ b/examples/memcache/main.tf
@@ -14,7 +14,24 @@
  * limitations under the License.
  */
 
+provider "google-beta" {
+  version = "~> 3.31.0"
+}
+
+module "private-service-access" {
+  source      = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
+  version     = "3.2.0"
+  project_id  = var.project
+  vpc_network = "default"
+}
+
 module "memcache" {
-  source  = "../../../examples/memcache"
-  project = var.project_id
+  source            = "../../modules/memcache"
+  name              = var.name
+  project           = var.project
+  memory_size_mb    = var.memory_size_mb
+  enable_apis       = var.enable_apis
+  cpu_count         = var.cpu_count
+  region            = var.region
+  module_depends_on = [module.private-service-access.peering_completed]
 }

--- a/examples/memcache/memcache.tf
+++ b/examples/memcache/memcache.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google-beta" {
+  version = "~> 3.31.0"
+}
+
+module "memcache" {
+  source         = "../../modules/memcache"
+  name           = "memcache"
+  project        = "memcache"
+  memory_size_mb = "1024"
+  enable_apis    = "true"
+  cpu_count      = "1"
+}

--- a/examples/memcache/memcache.tf
+++ b/examples/memcache/memcache.tf
@@ -22,7 +22,7 @@ module "memcache" {
   source         = "../../modules/memcache"
   name           = "memcache"
   project        = "memcache"
-  memory_size_mb = "1024"
-  enable_apis    = "true"
-  cpu_count      = "1"
+  memory_size_mb = 1024
+  enable_apis    = true
+  cpu_count      = 1
 }

--- a/examples/memcache/outputs.tf
+++ b/examples/memcache/outputs.tf
@@ -14,15 +14,31 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  version = "~> 3.31.0"
+
+output "project_id" {
+  value = var.project
 }
 
-module "memcache" {
-  source         = "../../modules/memcache"
-  name           = "memcache"
-  project        = "memcache"
-  memory_size_mb = 1024
-  enable_apis    = true
-  cpu_count      = 1
+output "name" {
+  value = var.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "cpu_count" {
+  value = var.cpu_count
+}
+
+output "memory_size_mb" {
+  value = var.memory_size_mb
+}
+
+output "output_id" {
+  value = module.memcache.id
+}
+
+output "output_region" {
+  value = module.memcache.region
 }

--- a/examples/memcache/variables.tf
+++ b/examples/memcache/variables.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project" {
+  description = "The ID of the project in which the resource belongs to."
+  type        = string
+}
+
+variable "name" {
+  description = "Name of memcache instance."
+  type        = string
+  default     = "example-memcache"
+}
+
+variable "region" {
+  description = "Region to create test instance."
+  type        = string
+  default     = "us-east1"
+}
+
+variable "memory_size_mb" {
+  description = "Memory size of test instance."
+  type        = number
+  default     = 1024
+}
+
+variable "cpu_count" {
+  description = "Number of cpu's for test instance."
+  type        = number
+  default     = 1
+}
+
+variable "enable_apis" {
+  description = "Flag for enabling memcache.googleapis.com in your project"
+  type        = bool
+  default     = true
+}

--- a/examples/memcache/versions.tf
+++ b/examples/memcache/versions.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    google      = ">= 3.14.0"
+    google-beta = ">= 3.31.0"
+  }
+}

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -13,7 +13,6 @@ A Terraform module for creating a fully functional Google Memorystore (memcache)
 | enable\_apis | Flag for enabling memcache.googleapis.com in your project | bool | `"true"` | no |
 | labels | The resource labels to represent user provided metadata. | map(string) | `<map>` | no |
 | memory\_size\_mb | Memcache memory size in MiB. Defaulted to 1024 | number | `"1024"` | no |
-| module\_depends\_on | Workaround to delay module initialization until private service access connection is available | list(any) | `<list>` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | string | n/a | yes |
 | node\_count | Number of nodes in the memcache instance. | number | `"1"` | no |
 | params | Parameters for the memcache process | map(string) | `"null"` | no |

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -13,6 +13,7 @@ A Terraform module for creating a fully functional Google Memorystore (memcache)
 | enable\_apis | Flag for enabling memcache.googleapis.com in your project | bool | `"true"` | no |
 | labels | The resource labels to represent user provided metadata. | map(string) | `<map>` | no |
 | memory\_size\_mb | Memcache memory size in MiB. Defaulted to 1024 | number | `"1024"` | no |
+| module\_depends\_on | Workaround to delay module initialization until private service access connection is available | list(any) | `<list>` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | string | n/a | yes |
 | node\_count | Number of nodes in the memcache instance. | number | `"1"` | no |
 | params | Parameters for the memcache process | map(string) | `"null"` | no |

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -2,12 +2,6 @@
 
 A Terraform module for creating a fully functional Google Memorystore (memcache) instance.
 
-## Compatibility
-This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x
-is [0.1.0](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/0.1.0).
-
-
-
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
@@ -17,13 +11,13 @@ is [0.1.0](https://registry.terraform.io/modules/terraform-google-modules/memory
 | cpu\_count | Number of CPUs per node | number | `"1"` | no |
 | display\_name | An arbitrary and optional user-provided name for the instance. | string | `"null"` | no |
 | enable\_apis | Flag for enabling memcache.googleapis.com in your project | bool | `"true"` | no |
-| labels | The resource labels to represent user provided metadata. | map(string) | `"null"` | no |
+| labels | The resource labels to represent user provided metadata. | map(string) | `<map>` | no |
 | memory\_size\_mb | Memcache memory size in MiB. Defaulted to 1024 | number | `"1024"` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | string | n/a | yes |
 | node\_count | Number of nodes in the memcache instance. | number | `"1"` | no |
 | params | Parameters for the memcache process | map(string) | `"null"` | no |
 | project | The ID of the project in which the resource belongs to. | string | n/a | yes |
-| region | The GCP region to use. | string | `"null"` | no |
+| region | The GCP region to use. | string | n/a | yes |
 | reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | string | `"null"` | no |
 | zones | Zones where memcache nodes should be provisioned. If not provided, all zones will be used. | list(string) | `"null"` | no |
 

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -1,0 +1,37 @@
+# [Google Cloud Memorystore Terraform Module](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/)
+
+A Terraform module for creating a fully functional Google Memorystore (memcache) instance.
+
+## Compatibility
+This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x
+is [0.1.0](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/0.1.0).
+
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| authorized\_network | The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used. | string | `"null"` | no |
+| cpu\_count | Number of CPUs per node | number | `"1"` | no |
+| display\_name | An arbitrary and optional user-provided name for the instance. | string | `"null"` | no |
+| enable\_apis | Flag for enabling memcache.googleapis.com in your project | bool | `"true"` | no |
+| labels | The resource labels to represent user provided metadata. | map(string) | `"null"` | no |
+| memory\_size\_mb | Memcache memory size in MiB. Defaulted to 1024 | number | `"1024"` | no |
+| name | The ID of the instance or a fully qualified identifier for the instance. | string | n/a | yes |
+| node\_count | Number of nodes in the memcache instance. | number | `"1"` | no |
+| params | Parameters for the memcache process | map(string) | `"null"` | no |
+| project | The ID of the project in which the resource belongs to. | string | n/a | yes |
+| region | The GCP region to use. | string | `"null"` | no |
+| reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | string | `"null"` | no |
+| zones | Zones where memcache nodes should be provisioned. If not provided, all zones will be used. | list(string) | `"null"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The memorystore instance ID. |
+| region | The region the instance lives in. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/memcache/main.tf
+++ b/modules/memcache/main.tf
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_memcache_instance" "self" {
+  depends_on         = [module.enable_apis]
+  provider           = google-beta
+  project            = var.project
+  zones              = var.zones
+  name               = var.name
+  region             = var.region
+  authorized_network = var.authorized_network
+  node_count         = var.node_count
+  display_name       = var.display_name
+  labels             = var.labels
+
+  node_config {
+    cpu_count      = var.cpu_count
+    memory_size_mb = var.memory_size_mb
+  }
+
+  dynamic "memcache_parameters" {
+    for_each = var.params == null ? [] : [var.params]
+    content {
+      params = memcache_parameters.value
+    }
+  }
+
+}
+
+
+module "enable_apis" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "8.0.1"
+
+  project_id  = var.project
+  enable_apis = var.enable_apis
+
+  activate_apis = [
+    "memcache.googleapis.com",
+  ]
+}

--- a/modules/memcache/main.tf
+++ b/modules/memcache/main.tf
@@ -23,7 +23,7 @@ resource "google_memcache_instance" "self" {
   region             = var.region
   authorized_network = var.authorized_network
   node_count         = var.node_count
-  display_name       = var.display_name
+  display_name       = var.display_name == null ? var.display_name : var.name
   labels             = var.labels
 
   node_config {

--- a/modules/memcache/outputs.tf
+++ b/modules/memcache/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "id" {
+  description = "The memorystore instance ID."
+  value       = google_memcache_instance.self.id
+}
+
+output "region" {
+  description = "The region the instance lives in."
+  value       = google_memcache_instance.self.region
+}

--- a/modules/memcache/variables.tf
+++ b/modules/memcache/variables.tf
@@ -77,7 +77,6 @@ variable "reserved_ip_range" {
   default     = null
 }
 
-
 variable "labels" {
   description = "The resource labels to represent user provided metadata."
   type        = map(string)
@@ -90,3 +89,8 @@ variable "params" {
   default     = null
 }
 
+variable "module_depends_on" {
+  description = "Workaround to delay module initialization until private service access connection is available"
+  type        = list(any)
+  default     = []
+}

--- a/modules/memcache/variables.tf
+++ b/modules/memcache/variables.tf
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "region" {
+  description = "The GCP region to use."
+  type        = string
+  default     = null
+}
+
+variable "project" {
+  description = "The ID of the project in which the resource belongs to."
+  type        = string
+}
+
+variable "enable_apis" {
+  description = "Flag for enabling memcache.googleapis.com in your project"
+  type        = bool
+  default     = true
+}
+
+variable "name" {
+  description = "The ID of the instance or a fully qualified identifier for the instance."
+  type        = string
+}
+
+variable "authorized_network" {
+  description = "The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used."
+  type        = string
+  default     = null
+}
+
+variable "node_count" {
+  description = "Number of nodes in the memcache instance."
+  type        = number
+  default     = 1
+}
+
+variable "cpu_count" {
+  description = "Number of CPUs per node"
+  type        = number
+  default     = 1
+}
+
+variable "memory_size_mb" {
+  description = "Memcache memory size in MiB. Defaulted to 1024"
+  type        = number
+  default     = 1024
+}
+
+variable "zones" {
+  description = "Zones where memcache nodes should be provisioned. If not provided, all zones will be used."
+  type        = list(string)
+  default     = null
+}
+
+variable "display_name" {
+  description = "An arbitrary and optional user-provided name for the instance."
+  type        = string
+  default     = null
+}
+
+variable "reserved_ip_range" {
+  description = "The CIDR range of internal addresses that are reserved for this instance."
+  type        = string
+  default     = null
+}
+
+
+variable "labels" {
+  description = "The resource labels to represent user provided metadata."
+  type        = map(string)
+  default     = null
+}
+
+variable "params" {
+  description = "Parameters for the memcache process"
+  type        = map(string)
+  default     = null
+}
+

--- a/modules/memcache/variables.tf
+++ b/modules/memcache/variables.tf
@@ -88,9 +88,3 @@ variable "params" {
   type        = map(string)
   default     = null
 }
-
-variable "module_depends_on" {
-  description = "Workaround to delay module initialization until private service access connection is available"
-  type        = list(any)
-  default     = []
-}

--- a/modules/memcache/variables.tf
+++ b/modules/memcache/variables.tf
@@ -17,7 +17,6 @@
 variable "region" {
   description = "The GCP region to use."
   type        = string
-  default     = null
 }
 
 variable "project" {
@@ -82,7 +81,7 @@ variable "reserved_ip_range" {
 variable "labels" {
   description = "The resource labels to represent user provided metadata."
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "params" {

--- a/test/fixtures/memcache/README.md
+++ b/test/fixtures/memcache/README.md
@@ -1,0 +1,28 @@
+# Minimal Test
+
+This test with create a new memcache instance.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cpu\_count | Number of cpu's for test instance. | number | `"1"` | no |
+| memory\_size\_mb | Memory size of test instance. | number | `"1024"` | no |
+| name | Name of memcache instance. | string | `"test-memcache"` | no |
+| project\_id | Google cloud project id to create memcache instance. | string | n/a | yes |
+| region | Region to create test instance. | string | `"us-east1"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cpu\_count |  |
+| memory\_size\_mb |  |
+| name |  |
+| output\_id |  |
+| output\_region |  |
+| project\_id |  |
+| region |  |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/test/fixtures/memcache/README.md
+++ b/test/fixtures/memcache/README.md
@@ -7,11 +7,7 @@ This test with create a new memcache instance.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| cpu\_count | Number of cpu's for test instance. | number | `"1"` | no |
-| memory\_size\_mb | Memory size of test instance. | number | `"1024"` | no |
-| name | Name of memcache instance. | string | `"test-memcache"` | no |
 | project\_id | Google cloud project id to create memcache instance. | string | n/a | yes |
-| region | Region to create test instance. | string | `"us-east1"` | no |
 
 ## Outputs
 

--- a/test/fixtures/memcache/main.tf
+++ b/test/fixtures/memcache/main.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "memcache" {
+  source = "../../../modules/memcache"
+
+  name = var.name
+
+  project        = var.project_id
+  region         = var.region
+  memory_size_mb = var.memory_size_mb
+  cpu_count      = var.cpu_count
+  enable_apis    = true
+}

--- a/test/fixtures/memcache/outputs.tf
+++ b/test/fixtures/memcache/outputs.tf
@@ -14,30 +14,31 @@
  * limitations under the License.
  */
 
+
 output "project_id" {
   value = var.project_id
 }
 
 output "name" {
-  value = var.name
+  value = module.memcache.name
 }
 
 output "region" {
-  value = var.region
+  value = module.memcache.region
+}
+
+output "cpu_count" {
+  value = module.memcache.cpu_count
 }
 
 output "memory_size_mb" {
-  value = var.memory_size_mb
+  value = module.memcache.memory_size_mb
 }
 
-
-output "cpu_count" {
-  value = var.cpu_count
-}
 output "output_id" {
-  value = module.memcache.id
+  value = module.memcache.output_id
 }
 
 output "output_region" {
-  value = module.memcache.region
+  value = module.memcache.output_region
 }

--- a/test/fixtures/memcache/outputs.tf
+++ b/test/fixtures/memcache/outputs.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value = var.project_id
+}
+
+output "name" {
+  value = var.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "memory_size_mb" {
+  value = var.memory_size_mb
+}
+
+
+output "cpu_count" {
+  value = var.cpu_count
+}
+output "output_id" {
+  value = module.memcache.id
+}
+
+output "output_region" {
+  value = module.memcache.region
+}

--- a/test/fixtures/memcache/terraform.tfvars.example
+++ b/test/fixtures/memcache/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# The google cloud project id to create resources in.
+project_id=""
+

--- a/test/fixtures/memcache/variables.tf
+++ b/test/fixtures/memcache/variables.tf
@@ -18,27 +18,3 @@ variable "project_id" {
   description = "Google cloud project id to create memcache instance."
   type        = string
 }
-
-variable "name" {
-  description = "Name of memcache instance."
-  type        = string
-  default     = "test-memcache"
-}
-
-variable "region" {
-  description = "Region to create test instance."
-  type        = string
-  default     = "us-east1"
-}
-
-variable "memory_size_mb" {
-  description = "Memory size of test instance."
-  type        = number
-  default     = 1024
-}
-
-variable "cpu_count" {
-  description = "Number of cpu's for test instance."
-  type        = number
-  default     = 1
-}

--- a/test/fixtures/memcache/variables.tf
+++ b/test/fixtures/memcache/variables.tf
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Google cloud project id to create memcache instance."
+  type        = string
+}
+
+variable "name" {
+  description = "Name of memcache instance."
+  type        = string
+  default     = "test-memcache"
+}
+
+variable "region" {
+  description = "Region to create test instance."
+  type        = string
+  default     = "us-east1"
+}
+
+variable "memory_size_mb" {
+  description = "Memory size of test instance."
+  type        = number
+  default     = 1024
+}
+
+variable "cpu_count" {
+  description = "Number of cpu's for test instance."
+  type        = number
+  default     = 1
+}

--- a/test/fixtures/memcache/versions.tf
+++ b/test/fixtures/memcache/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/test/integration/memcache/controls/gcloud.rb
+++ b/test/integration/memcache/controls/gcloud.rb
@@ -1,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id       = attribute('project_id')
+name             = attribute('name')
+region           = attribute('region')
+cpu_count        = attribute('cpu_count')
+memory_size_mb   = attribute('memory_size_mb')
+
+output_id        = attribute('output_id')
+output_region    = attribute('output_region')
+
+describe 'Outputs' do
+  it 'should reflect inputted variables' do
+    expect(output_region).to eq region
+  end
+
+  it 'should have a valid id' do
+    expect(output_id).to end_with name
+  end
+end
+
+control 'memcache-instance' do
+  describe command("gcloud beta memcache instances describe #{name} --project=#{project_id} --region=#{region} --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+
+    let(:metadata) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    it { expect(metadata['nodeConfig']['cpuCount']).to eq(cpu_count) }
+    it { expect(metadata['nodeConfig']['memorySizeMb']).to eq(memory_size_mb) }
+
+  end
+end

--- a/test/integration/memcache/controls/gcloud.rb
+++ b/test/integration/memcache/controls/gcloud.rb
@@ -44,8 +44,12 @@ control 'memcache-instance' do
       end
     end
 
-    it { expect(metadata['nodeConfig']['cpuCount']).to eq(cpu_count) }
-    it { expect(metadata['nodeConfig']['memorySizeMb']).to eq(memory_size_mb) }
+    it "nodeConfig.cpucount matches var.cpu_count" do
+       expect(metadata['nodeConfig']['cpuCount']).to eq(cpu_count)
+    end
+    it "nodeConfig.memorySizeMb matches var.memory_size_mb" do
+      expect(metadata['nodeConfig']['memorySizeMb']).to eq(memory_size_mb)
+    end
 
   end
 end

--- a/test/integration/memcache/inspec.yml
+++ b/test/integration/memcache/inspec.yml
@@ -1,0 +1,27 @@
+name: memcache
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: name
+    required: true
+    type: string
+  - name: region
+    required: true
+    type: string
+  - name: cpu_count
+    required: true
+    type: numeric
+  - name: memory_size_mb
+    required: true
+    type: numeric
+  - name: node_count
+    required: true
+    type: numeric
+  - name: output_id
+    required: true
+    type: string
+  - name: output_region
+    required: true
+    type: string
+

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -18,12 +18,13 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 8.1.0"
 
-  name                = "ci-memory-store"
-  random_project_id   = true
-  org_id              = var.org_id
-  folder_id           = var.folder_id
-  billing_account     = var.billing_account
-  auto_create_network = true
+  name                    = "ci-memory-store"
+  random_project_id       = true
+  org_id                  = var.org_id
+  folder_id               = var.folder_id
+  billing_account         = var.billing_account
+  default_service_account = "delete"
+  auto_create_network     = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -34,22 +34,4 @@ module "project" {
   ]
 }
 
-data "google_compute_network" "peering_network" {
-  project = module.project.project_id
-  name    = "default"
-}
 
-resource "google_compute_global_address" "private_ip_alloc" {
-  project       = module.project.project_id
-  name          = "private-ip-alloc"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = data.google_compute_network.peering_network.self_link
-}
-
-resource "google_service_networking_connection" "ci-memory-store" {
-  network                 = data.google_compute_network.peering_network.self_link
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
-}

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -27,8 +27,28 @@ module "project" {
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",
-    "storage-api.googleapis.com",
     "serviceusage.googleapis.com",
     "redis.googleapis.com",
+    "memcache.googleapis.com",
   ]
+}
+
+data "google_compute_network" "peering_network" {
+  project = module.project.project_id
+  name    = "default"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  project       = module.project.project_id
+  name          = "private-ip-alloc"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.peering_network.self_link
+}
+
+resource "google_service_networking_connection" "ci-memory-store" {
+  network                 = data.google_compute_network.peering_network.self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.1.0"
 
   name                = "ci-memory-store"
   random_project_id   = true

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.31.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.31.0"
 }


### PR DESCRIPTION
This PR is mostly working with 2 exceptions:

1. When ever I apply or destroy the resource, the response from the API is always a 403 claiming the API isn't enabled. 
```Error: Error waiting for Deleting Instance: error while retrieving operation: googleapi: Error 403: Cloud Memorystore for Memcached API has not been used in project ######## before or it is disabled```

However, I assure you the API is enabled, and the GSA creating the resource has permissions.. because the instance actually gets created! (or destroyed if I need be). it's just the API seems to respond with a 403 no matter what.

2.  When I attempt to set `memcache_parameters` attribute, it plans fine, but then fails to apply w/ a different error from the API:
```
Error: Error waiting for Deleting Instance: error while retrieving operation: googleapi: Error 403: Cloud Memorystore for Memcached API has not been used in project 1018575646121 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/memcache.googleapis.com/overview?project=1018575646121 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.Help",
    "links": [
      {
        "description": "Google developers console API activation",
        "url": "https://console.developers.google.com/apis/api/memcache.googleapis.com/overview?project=1018575646121"
      }
    ]
  }
]
```

I suspect exception 2 is going to be resolved w/ the next release of the google-beta terraform provider, [because I see a fix was merged into master but is not in the latest available release tag](https://github.com/terraform-providers/terraform-provider-google-beta/pull/2261).

@morgante hoping you can provide some guidance here, thanks!
