### PR TITLE
Remove interpolation-only expressions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,8 @@ module "enable_apis" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "4.0.1"
 
-  project_id  = "${var.project}"
-  enable_apis = "${var.enable_apis}"
+  project_id  = var.project
+  enable_apis = var.enable_apis
 
   activate_apis = [
     "redis.googleapis.com",


### PR DESCRIPTION
Hi!

Interpolation-only expressions are deprecated since terraform 0.11

Terraform warning: 
```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/memorystore/main.tf line 44, in module "enable_apis":
  44:   project_id  = "${var.project}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

Closes #31 

