### PR TITLE
Upgrade version of project_services module to 9.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "google_redis_instance" "default" {
 
 module "enable_apis" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "4.0.1"
+  version = "9.2.0"
 
   project_id  = var.project
   enable_apis = var.enable_apis

--- a/modules/memcache/main.tf
+++ b/modules/memcache/main.tf
@@ -43,7 +43,7 @@ resource "google_memcache_instance" "self" {
 
 module "enable_apis" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "8.0.1"
+  version = "9.2.0"
 
   project_id  = var.project
   enable_apis = var.enable_apis


### PR DESCRIPTION
Upgrade version constraint of `project_services` module to `v9.2.0`.

It allows to use Terraform 0.13.

```hcl
terraform {
  required_version = ">=0.12.6, <0.14"
}
```