### PR TITLE
redis instance creation bug fixing and making the open source module to suppport terraform 0.14 version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "google_redis_instance" "default" {
 
 module "enable_apis" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "9.2.0"
+  version = "10.1.0"
 
   project_id  = var.project
   enable_apis = var.enable_apis

--- a/variables.tf
+++ b/variables.tf
@@ -86,8 +86,6 @@ variable "display_name" {
 
 variable "reserved_ip_range" {
   description = "The CIDR range of internal addresses that are reserved for this instance."
-  type        = string
-  default     = null
 }
 
 variable "connect_mode" {


### PR DESCRIPTION
HI Team,

By making this changes, we will be able to assing the reserved IP range for redis instance and also it will be able to support terraform version greater that 0.13 & 0.14 as well.