### PR TITLE
add auth_enabled and auth_string attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ module "memorystore" {
 | region | The GCP region to use. | string | `"null"` | no |
 | reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | string | `"null"` | no |
 | tier | The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier | string | `"STANDARD_HA"` | no |
+| auth_enabled | Indicates whether OSS Redis AUTH is enabled for the instance. If set to "true" AUTH is enabled on the instance. Default value is "false" meaning AUTH is disabled. | bool | `false` | no |
+| auth_string | AUTH String set on the instance. This field will only be populated if auth_enabled is true. | string | `"null"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,9 @@ resource "google_redis_instance" "default" {
   display_name      = var.display_name
   reserved_ip_range = var.reserved_ip_range
 
+  auth_enabled = var.auth_enabled
+  auth_string = var.auth_string
+
   labels = var.labels
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,15 @@ variable "labels" {
   type        = map(string)
   default     = null
 }
+
+variable "auth_enabled" {
+  description = "Indicates whether OSS Redis AUTH is enabled for the instance."
+  type        = bool
+  default     = false
+}
+
+variable "auth_string" {
+  description = "AUTH String set on the instance. This field will only be populated if auth_enabled is true."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Hello,
this PR add `auth_enabled` and `auth_string` attributes.

Reference:
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance#auth_enabled
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance#auth_string