### PR TITLE
Add discovery endpoint output to memcache module

### DIFF
--- a/examples/memcache/outputs.tf
+++ b/examples/memcache/outputs.tf
@@ -46,3 +46,7 @@ output "output_region" {
 output "output_nodes" {
   value = module.memcache.nodes
 }
+
+output "output_discovery" {
+  value = module.memcache.discovery
+}

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -25,9 +25,9 @@ A Terraform module for creating a fully functional Google Memorystore (memcache)
 
 | Name | Description |
 |------|-------------|
+| discovery | The memorystore discovery endpoint. |
 | id | The memorystore instance ID. |
 | nodes | Data about the memcache nodes |
 | region | The region the instance lives in. |
-| discovery | The memorystore discovery endpoint. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -28,5 +28,6 @@ A Terraform module for creating a fully functional Google Memorystore (memcache)
 | id | The memorystore instance ID. |
 | nodes | Data about the memcache nodes |
 | region | The region the instance lives in. |
+| discovery | The memorystore discovery endpoint. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/memcache/outputs.tf
+++ b/modules/memcache/outputs.tf
@@ -31,5 +31,5 @@ output "nodes" {
 
 output "discovery" {
   description = "The memorystore discovery endpoint."
-  value = google_memcache_instance.self.discovery_endpoint
+  value       = google_memcache_instance.self.discovery_endpoint
 }

--- a/modules/memcache/outputs.tf
+++ b/modules/memcache/outputs.tf
@@ -28,3 +28,8 @@ output "nodes" {
   description = "Data about the memcache nodes"
   value       = google_memcache_instance.self.memcache_nodes
 }
+
+output "discovery" {
+  description = "The memorystore discovery endpoint."
+  value = google_memcache_instance.self.discovery_endpoint
+}

--- a/test/integration/memcache/inspec.yml
+++ b/test/integration/memcache/inspec.yml
@@ -27,4 +27,6 @@ attributes:
   - name: output_nodes
     required: true
     type: hash
-
+  - name: output_discovery
+    required: true
+    type: string


### PR DESCRIPTION
google_memcache_instance exports a discovery_endpoint that would be useful to upstream modules for things like assigning a DNS name to that endpoint instead of each node address.



