### PR TITLE
Updated version in the README example hcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check the [examples/](./examples/) directory for more.
 ```hcl
 module "memorystore" {
   source  = "terraform-google-modules/memorystore/google"
-  version = "2.0.0"
+  version = "4.0.0"
 
   name    = "my-memorystore"
   project = "my-gcp-project"


### PR DESCRIPTION
The version in the README.md's example used version 2.0.0 of the module, which is old. The 4.0.0 is the current latest version.

Fixes #69 