### PR TITLE
added replica_count and replicas_mode functionality

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ resource "google_redis_instance" "default" {
   project        = var.project
   name           = var.name
   tier           = var.tier
+  replica_count      = var.tier == "STANDARD_HA" ? var.replica_count : null
+  read_replicas_mode = var.tier == "STANDARD_HA" ? var.read_replicas_mode : null
   memory_size_gb = var.memory_size_gb
   connect_mode   = var.connect_mode
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "memory_size_gb" {
   default     = 1
 }
 
+variable "replica_count" {
+  description = "The number of replicas. can"
+  type        = number
+  default     = 1
+}
+
+variable "read_replicas_mode" {
+  description = "Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode "
+  type        = string
+  default     = "READ_REPLICAS_DISABLED"
+}
+
 variable "location_id" {
   description = "The zone where the instance will be provisioned. If not provided, the service will choose a zone for the instance. For STANDARD_HA tier, instances will be created across two zones for protection against zonal failures. If [alternativeLocationId] is also provided, it must be different from [locationId]."
   type        = string


### PR DESCRIPTION
I added the options to choose the read replicas types and number according to gcp documentation and terrraform
https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance