### PR TITLE
added replica_count and replicas_mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ module "memorystore" {
 | memory\_size\_gb | Redis memory size in GiB. Defaulted to 1 GiB | `number` | `1` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | `string` | n/a | yes |
 | project | The ID of the project in which the resource belongs to. | `string` | n/a | yes |
+| read\_replicas\_mode | Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode | `string` | `"READ_REPLICAS_DISABLED"` | no |
 | redis\_configs | The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs) | `map(any)` | `{}` | no |
 | redis\_version | The version of Redis software. | `string` | `null` | no |
 | region | The GCP region to use. | `string` | `null` | no |
+| replica\_count | The number of replicas. can | `number` | `1` | no |
 | reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | `string` | `null` | no |
 | tier | The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier | `string` | `"STANDARD_HA"` | no |
 | transit\_encryption\_mode | The TLS mode of the Redis instance, If not provided, TLS is enabled for the instance. | `string` | `"SERVER_AUTHENTICATION"` | no |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "memorystore" {
 | redis\_configs | The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs) | `map(any)` | `{}` | no |
 | redis\_version | The version of Redis software. | `string` | `null` | no |
 | region | The GCP region to use. | `string` | `null` | no |
-| replica\_count | The number of replicas. can | `number` | `1` | no |
+| replica\_count | The number of replicas. can | `number` | `null` | no |
 | reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | `string` | `null` | no |
 | tier | The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier | `string` | `"STANDARD_HA"` | no |
 | transit\_encryption\_mode | The TLS mode of the Redis instance, If not provided, TLS is enabled for the instance. | `string` | `"SERVER_AUTHENTICATION"` | no |

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ resource "google_redis_instance" "default" {
   project        = var.project
   name           = var.name
   tier           = var.tier
+  replica_count      = var.tier == "STANDARD_HA" ? var.replica_count : null
+  read_replicas_mode = var.tier == "STANDARD_HA" ? var.read_replicas_mode : null
   memory_size_gb = var.memory_size_gb
   connect_mode   = var.connect_mode
 

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,13 @@
 resource "google_redis_instance" "default" {
   depends_on = [module.enable_apis]
 
-  project        = var.project
-  name           = var.name
-  tier           = var.tier
+  project            = var.project
+  name               = var.name
+  tier               = var.tier
   replica_count      = var.tier == "STANDARD_HA" ? var.replica_count : null
   read_replicas_mode = var.tier == "STANDARD_HA" ? var.read_replicas_mode : null
-  memory_size_gb = var.memory_size_gb
-  connect_mode   = var.connect_mode
+  memory_size_gb     = var.memory_size_gb
+  connect_mode       = var.connect_mode
 
   region                  = var.region
   location_id             = var.location_id

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "memory_size_gb" {
 variable "replica_count" {
   description = "The number of replicas. can"
   type        = number
-  default     = 1
+  default     = null
 }
 
 variable "read_replicas_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "memory_size_gb" {
   default     = 1
 }
 
+variable "replica_count" {
+  description = "The number of replicas. can"
+  type        = number
+  default     = 1
+}
+
+variable "read_replicas_mode" {
+  description = "Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode "
+  type        = string
+  default     = "READ_REPLICAS_DISABLED"
+}
+
 variable "location_id" {
   description = "The zone where the instance will be provisioned. If not provided, the service will choose a zone for the instance. For STANDARD_HA tier, instances will be created across two zones for protection against zonal failures. If [alternativeLocationId] is also provided, it must be different from [locationId]."
   type        = string


### PR DESCRIPTION
I added the options to choose the read replicas types and number according to gcp documentation and terrraform
https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance