### PR TITLE
fix: add sensitive true flag to output auth_string

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -47,4 +47,5 @@ output "persistence_iam_identity" {
 output "auth_string" {
   description = "AUTH String set on the instance. This field will only be populated if auth_enabled is true."
   value       = google_redis_instance.default.auth_string
+  sensitive   = true
 }


### PR DESCRIPTION
Fix: add sensitive flag on the `auth_string` output so it stops breaking applies on tf 1+

Solves issue https://github.com/terraform-google-modules/terraform-google-memorystore/issues/86