### PR TITLE
Feat:! Add Redis instance persistent configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "memorystore" {
 | maintenance\_policy | The maintenance policy for an instance. | <pre>object({<br>    day = string<br>    start_time = object({<br>      hours   = number<br>      minutes = number<br>      seconds = number<br>      nanos   = number<br>    })<br>  })</pre> | `null` | no |
 | memory\_size\_gb | Redis memory size in GiB. Defaulted to 1 GiB | `number` | `1` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | `string` | n/a | yes |
-| persistence\_config | The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig) | <pre>object({<br>    persistence_mode        = string<br>    rdb_snapshot_period     = string<br>    rdb_snapshot_start_time = optional(string)<br>  })</pre> | `null` | no |
+| persistence\_config | The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig) | <pre>object({<br>    persistence_mode    = string<br>    rdb_snapshot_period = string<br>  })</pre> | `null` | no |
 | project | The ID of the project in which the resource belongs to. | `string` | n/a | yes |
 | read\_replicas\_mode | Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode | `string` | `"READ_REPLICAS_DISABLED"` | no |
 | redis\_configs | The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs) | `map(any)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "memorystore" {
 | maintenance\_policy | The maintenance policy for an instance. | <pre>object({<br>    day = string<br>    start_time = object({<br>      hours   = number<br>      minutes = number<br>      seconds = number<br>      nanos   = number<br>    })<br>  })</pre> | `null` | no |
 | memory\_size\_gb | Redis memory size in GiB. Defaulted to 1 GiB | `number` | `1` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | `string` | n/a | yes |
+| persistence\_config | The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig) | <pre>object({<br>    persistence_mode        = string<br>    rdb_snapshot_period     = string<br>    rdb_snapshot_start_time = optional(string)<br>  })</pre> | `null` | no |
 | project | The ID of the project in which the resource belongs to. | `string` | n/a | yes |
 | read\_replicas\_mode | Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode | `string` | `"READ_REPLICAS_DISABLED"` | no |
 | redis\_configs | The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs) | `map(any)` | `{}` | no |

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -28,9 +28,9 @@ module "memstore" {
   transit_encryption_mode = "SERVER_AUTHENTICATION"
   authorized_network      = module.test-vpc-module.network_id
   memory_size_gb          = 1
-  persistence_config      = {
-      "persistence_mode" = "RDB",
-      "rdb_snapshot_period" = "ONE_HOUR"
+  persistence_config = {
+    "persistence_mode"    = "RDB",
+    "rdb_snapshot_period" = "ONE_HOUR"
   }
 
 }

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -28,4 +28,9 @@ module "memstore" {
   transit_encryption_mode = "SERVER_AUTHENTICATION"
   authorized_network      = module.test-vpc-module.network_id
   memory_size_gb          = 1
+  persistence_config      = {
+      "persistence_mode" = "RDB",
+      "rdb_snapshot_period" = "ONE_HOUR"
+  }
+
 }

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,14 @@ resource "google_redis_instance" "default" {
   redis_configs     = var.redis_configs
   display_name      = var.display_name
   reserved_ip_range = var.reserved_ip_range
+  dynamic "persistence_config" {
+    for_each = var.persistence_config != null ? [var.persistence_config] : []
+    content {
+        persistence_mode = persistence_config.value["persistence_mode"]
+        rdb_snapshot_period = persistence_config.value["rdb_snapshot_period"]
+        rdb_snapshot_start_time = persistence_config.value["rdb_snapshot_start_time"]
+    }
+  }
 
   labels = var.labels
 

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,9 @@ resource "google_redis_instance" "default" {
   dynamic "persistence_config" {
     for_each = var.persistence_config != null ? [var.persistence_config] : []
     content {
-        persistence_mode = persistence_config.value["persistence_mode"]
-        rdb_snapshot_period = persistence_config.value["rdb_snapshot_period"]
-        rdb_snapshot_start_time = persistence_config.value["rdb_snapshot_start_time"]
+      persistence_mode        = persistence_config.value["persistence_mode"]
+      rdb_snapshot_period     = persistence_config.value["rdb_snapshot_period"]
+      rdb_snapshot_start_time = persistence_config.value["rdb_snapshot_start_time"]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ resource "google_redis_instance" "default" {
     content {
       persistence_mode        = persistence_config.value["persistence_mode"]
       rdb_snapshot_period     = persistence_config.value["rdb_snapshot_period"]
-      rdb_snapshot_start_time = persistence_config.value["rdb_snapshot_start_time"]
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,9 +93,8 @@ variable "redis_configs" {
 variable "persistence_config" {
   description = "The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig)"
   type = object({
-    persistence_mode        = string
-    rdb_snapshot_period     = string
-    rdb_snapshot_start_time = optional(string)
+    persistence_mode    = string
+    rdb_snapshot_period = string
   })
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -93,8 +93,8 @@ variable "redis_configs" {
 variable "persistence_config" {
   description = "The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig)"
   type = object({
-    persistence_mode = string
-    rdb_snapshot_period = string
+    persistence_mode        = string
+    rdb_snapshot_period     = string
     rdb_snapshot_start_time = optional(string)
   })
   default = null

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,16 @@ variable "redis_configs" {
   default     = {}
 }
 
+variable "persistence_config" {
+  description = "The Redis persistence configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig)"
+  type = object({
+    persistence_mode = string
+    rdb_snapshot_period = string
+    rdb_snapshot_start_time = optional(string)
+  })
+  default = null
+}
+
 variable "display_name" {
   description = "An arbitrary and optional user-provided name for the instance."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.28.0, < 5.0"
+      version = ">= 4.41.0, < 5.0"
     }
   }
 


### PR DESCRIPTION
Example:

```
 persistence_config      = {
      "persistence_mode" = "RDB",
      "rdb_snapshot_period" = "ONE_HOUR"
  }
```
Reference document: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance#persistence_config

- [x] terraform fmt.
- [x]  make generate_docs.