### PR TITLE
Feat: add support for using read replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "memorystore" {
 | region | The GCP region to use. | `string` | `null` | no |
 | replica\_count | The number of replicas. can | `number` | `null` | no |
 | reserved\_ip\_range | The CIDR range of internal addresses that are reserved for this instance. | `string` | `null` | no |
+| secondary\_ip\_range | Optional. Additional IP range for node placement. Required when enabling read replicas on an existing instance. | `string` | `null` | no |
 | tier | The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier | `string` | `"STANDARD_HA"` | no |
 | transit\_encryption\_mode | The TLS mode of the Redis instance, If not provided, TLS is enabled for the instance. | `string` | `"SERVER_AUTHENTICATION"` | no |
 
@@ -61,6 +62,7 @@ module "memorystore" {
 | id | The memorystore instance ID. |
 | persistence\_iam\_identity | Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time |
 | port | The port number of the exposed Redis endpoint. |
+| read\_endpoint | The IP address of the exposed readonly Redis endpoint. |
 | region | The region the instance lives in. |
 | server\_ca\_certs | List of server CA certificates for the instance |
 

--- a/main.tf
+++ b/main.tf
@@ -32,10 +32,11 @@ resource "google_redis_instance" "default" {
   authorized_network   = var.authorized_network
   customer_managed_key = var.customer_managed_key
 
-  redis_version     = var.redis_version
-  redis_configs     = var.redis_configs
-  display_name      = var.display_name
-  reserved_ip_range = var.reserved_ip_range
+  redis_version      = var.redis_version
+  redis_configs      = var.redis_configs
+  display_name       = var.display_name
+  reserved_ip_range  = var.reserved_ip_range
+  secondary_ip_range = var.secondary_ip_range
 
   labels = var.labels
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,11 @@ output "port" {
   value       = google_redis_instance.default.port
 }
 
+output "read_endpoint" {
+  description = " The IP address of the exposed readonly Redis endpoint."
+  value       = google_redis_instance.default.read_endpoint
+}
+
 output "region" {
   description = "The region the instance lives in."
   value       = google_redis_instance.default.region

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "reserved_ip_range" {
   default     = null
 }
 
+variable "secondary_ip_range" {
+  description = "Optional. Additional IP range for node placement. Required when enabling read replicas on an existing instance."
+  type        = string
+  default     = null
+}
+
 variable "connect_mode" {
   description = "The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING."
   type        = string


### PR DESCRIPTION
Changes added to support setup with read replicas.
Input `secondary_ip_range` is required while enabling read replica on existing memorystore instance.
Output `read_endpoint` is useful when read replicas are enabled.