### PR TITLE
Fix: Change memcached's maintenance_policy duration attribute type.

### DIFF
--- a/examples/memcache/main.tf
+++ b/examples/memcache/main.tf
@@ -33,6 +33,16 @@ module "memcache" {
   cpu_count          = "1"
   region             = "us-east1"
   authorized_network = module.test-vpc-module.network_id
+  maintenance_policy = {
+    day = "MONDAY"
+    duration = "10800s"
+    start_time = {
+      hours   = 8
+      minutes = 0
+      seconds = 0
+      nanos   = 0
+    }
+  }
   depends_on = [
     module.private-service-access.peering_completed
   ]

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -12,7 +12,7 @@ A Terraform module for creating a fully functional Google Memorystore (memcache)
 | display\_name | An arbitrary and optional user-provided name for the instance. | `string` | `null` | no |
 | enable\_apis | Flag for enabling memcache.googleapis.com in your project | `bool` | `true` | no |
 | labels | The resource labels to represent user provided metadata. | `map(string)` | `{}` | no |
-| maintenance\_policy | The maintenance policy for an instance. | <pre>object({<br>    day      = string<br>    duration = number<br>    start_time = object({<br>      hours   = number<br>      minutes = number<br>      seconds = number<br>      nanos   = number<br>    })<br>  })</pre> | `null` | no |
+| maintenance\_policy | The maintenance policy for an instance. | <pre>object({<br>    day      = string<br>    duration = string<br>    start_time = object({<br>      hours   = number<br>      minutes = number<br>      seconds = number<br>      nanos   = number<br>    })<br>  })</pre> | `null` | no |
 | memory\_size\_mb | Memcache memory size in MiB. Defaulted to 1024 | `number` | `1024` | no |
 | name | The ID of the instance or a fully qualified identifier for the instance. | `string` | n/a | yes |
 | node\_count | Number of nodes in the memcache instance. | `number` | `1` | no |

--- a/modules/memcache/variables.tf
+++ b/modules/memcache/variables.tf
@@ -88,7 +88,7 @@ variable "maintenance_policy" {
   # type = object(any)
   type = object({
     day      = string
-    duration = number
+    duration = string
     start_time = object({
       hours   = number
       minutes = number


### PR DESCRIPTION
The duration attribute of the maintenance policy for Memcached is expected a string not a number. [Doc Link](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/memcache_instance#duration)

Upon passing the number in Memcached maintence_policy, terraform is throwing an `Illegal duration format` error because it's expecting the value to end with 's', for example, '10800s'. Refer to the attached screenshot.
<img width="1723" alt="Screenshot 2023-03-16 at 3 38 18 PM" src="https://user-images.githubusercontent.com/30438229/225605590-269f5318-edcc-471a-95eb-4d83c2c8c629.png">

Since the value type is set as a number right now which means it will not expect string and throws ` The given value is not suitable for module.memcached_memorystore.var.maintenance_policy`.

Added maintenance_policy block in the example.

**Note:** The code is tested and working. It's able to create a Memcached memstore with a maintenance policy with duration.
