### PR TITLE
feat: create backup module

### DIFF
--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -1,0 +1,55 @@
+# GCP REDIS Backup
+
+## Exports to GCS
+
+Allow to export Redis data to a bucket. 
+
+### Deleting old exports
+
+The export workflow does not take care about deleting old backups. Please take care about that yourself.
+You can use [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle) to delete old exports.
+
+## Required APIs
+
+- `workflows.googleapis.com`
+- `cloudscheduler.googleapis.com`
+
+## Monitoring
+
+Monitoring your exports is not part of this module.
+Please ensure that you monitor for failed workflows to ensure you have regular backups/exports.
+
+A good metric could be to monitor for workflow executions that not succeeded:
+
+```mql
+fetch workflows.googleapis.com/Workflow
+| metric 'workflows.googleapis.com/finished_execution_count'
+| filter (metric.status != 'SUCCEEDED')
+| group_by 1d,
+    [value_finished_execution_count_mean: mean(value.finished_execution_count)]
+| every 1d
+| condition val() > 0 '1'
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| export\_schedule | The cron schedule to execute the export to GCS | `string` | `"15 3 * * *"` | no |
+| export\_uri | The bucket and path uri for exporting to GCS | `string` | n/a | yes |
+| project\_id | The project ID | `string` | n/a | yes |
+| region | The region where to run the workflow | `string` | `"us-central1"` | no |
+| scheduler\_timezone | The Timezone in which the Scheduler Jobs are triggered | `string` | `"Etc/GMT"` | no |
+| service\_account | The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the REDIS Admin and the Workflows Invoker role to that | `string` | `null` | no |
+| redis\_instance | The name of the REDIS instance to backup | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| export\_workflow\_name | The name for export workflow |
+| region | The region for running the scheduler and workflow |
+| service\_account | The service account email running the scheduler and workflow |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+locals {
+  create_service_account = var.service_account == null || var.service_account == "" ? true : false
+  service_account        = local.create_service_account ? google_service_account.redis_backup_serviceaccount[0].email : var.service_account
+}
+
+
+data "google_redis_instance" "backup_instance" {
+  name    = var.redis_instance
+  project = var.project_id
+}
+
+################################
+#                              #
+#   Service Account and IAM    #
+#                              #
+################################
+resource "google_service_account" "redis_backup_serviceaccount" {
+  count        = local.create_service_account ? 1 : 0
+  account_id   = trimsuffix(substr("backup-${var.redis_instance}", 0, 28), "-")
+  display_name = "Managed by Terraform - Service account for backup of redis Instance ${var.redis_instance}"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "redis_backup_serviceaccount_redis_admin" {
+  count   = local.create_service_account ? 1 : 0
+  member  = "serviceAccount:${google_service_account.redis_backup_serviceaccount[0].email}"
+  role    = "roles/redis.admin"
+  project = var.project_id
+}
+
+resource "google_project_iam_member" "redis_backup_serviceaccount_workflow_invoker" {
+  count   = local.create_service_account ? 1 : 0
+  member  = "serviceAccount:${google_service_account.redis_backup_serviceaccount[0].email}"
+  role    = "roles/workflows.invoker"
+  project = var.project_id
+}
+
+################################
+#                              #
+#       External Backups       #
+#                              #
+################################
+resource "google_workflows_workflow" "redis_export" {
+  name            = "redis-export-${var.redis_instance}"
+  description     = "Workflow for backing up the Redis Instance"
+  project         = var.project_id
+  service_account = local.service_account
+  source_contents = templatefile("${path.module}/templates/export.yaml.tftpl", {
+    project                = var.project_id
+    region                 = var.region
+    instanceName           = var.redis_instance
+    gcsBucket              = var.export_uri
+  })
+}
+
+resource "google_cloud_scheduler_job" "redis_export" {
+  name        = "redis-export-${var.redis_instance}"
+  project     = var.project_id
+  region      = var.region
+  description = "Managed by Terraform - Triggers a Redis Export via Workflows"
+  schedule    = var.export_schedule
+  time_zone   = var.scheduler_timezone
+
+  http_target {
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.redis_export.id}/executions"
+    http_method = "POST"
+    oauth_token {
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+      service_account_email = local.service_account
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "redis_instance_account" {
+  bucket = split("/", var.export_uri)[2] #Get the name of the bucket out of the URI
+  member = data.google_redis_instance.backup_instance.persistence_iam_identity
+  role   = "roles/storage.objectCreator"
+}

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -63,10 +63,10 @@ resource "google_workflows_workflow" "redis_export" {
   project         = var.project_id
   service_account = local.service_account
   source_contents = templatefile("${path.module}/templates/export.yaml.tftpl", {
-    project                = var.project_id
-    region                 = var.region
-    instanceName           = var.redis_instance
-    gcsBucket              = var.export_uri
+    project      = var.project_id
+    region       = var.region
+    instanceName = var.redis_instance
+    gcsBucket    = var.export_uri
   })
 }
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -93,3 +93,10 @@ resource "google_storage_bucket_iam_member" "redis_instance_account" {
   member = data.google_redis_instance.backup_instance.persistence_iam_identity
   role   = "roles/storage.objectCreator"
 }
+
+# mandatory to allow export to distinct project than the redis instance one
+resource "google_storage_bucket_iam_member" "redis_instance_account_bis" {
+  bucket = split("/", var.export_uri)[2] #Get the name of the bucket out of the URI
+  member = data.google_redis_instance.backup_instance.persistence_iam_identity
+  role   = "roles/storage.legacyBucketReader"
+}

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -1,0 +1,83 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-redis-db
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  title: GCP Redis Backup
+  source:
+    repo: https://github.com/terraform-google-modules/terraform-google-memorystore
+    sourceType: git
+  actuationTool:
+    type: Terraform
+    version: '>= 0.13'
+  description: {}
+  variables:
+  - name: export_schedule
+    description: The cron schedule to execute the export to GCS
+    type: string
+    default: 15 3 * * *
+  - name: export_uri
+    description: The bucket and path uri for exporting to GCS
+    type: string
+    required: true
+  - name: project_id
+    description: The project ID
+    type: string
+    required: true
+  - name: region
+    description: The region where to run the workflow
+    type: string
+    default: us-central1
+  - name: scheduler_timezone
+    description: The Timezone in which the Scheduler Jobs are triggered
+    type: string
+    default: Etc/GMT
+  - name: service_account
+    description: The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Redis Admin and the Workflows Invoker role to that
+    type: string
+  - name: redis_instance
+    description: The name of the REDIS instance to export
+    type: string
+    required: true
+  outputs:
+  - name: export_workflow_name
+    description: The name for export workflow
+  - name: region
+    description: The region for running the scheduler and workflow
+  - name: service_account
+    description: The service account email running the scheduler and workflow
+  roles:
+  - level: Project
+    roles:
+    - roles/redis.admin
+    - roles/compute.networkAdmin
+    - roles/iam.serviceAccountAdmin
+    - roles/resourcemanager.projectIamAdmin
+    - roles/storage.admin
+    - roles/workflows.admin
+    - roles/cloudscheduler.admin
+    - roles/iam.serviceAccountUser
+  services:
+  - cloudresourcemanager.googleapis.com
+  - compute.googleapis.com
+  - servicenetworking.googleapis.com
+  - redisadmin.googleapis.com
+  - iam.googleapis.com
+  - workflows.googleapis.com
+  - cloudscheduler.googleapis.com

--- a/modules/backup/outputs.tf
+++ b/modules/backup/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+output "export_workflow_name" {
+  value       = google_workflows_workflow.redis_export.name
+  description = "The name for export workflow"
+}
+
+output "service_account" {
+  value       = local.service_account
+  description = "The service account email running the scheduler and workflow"
+}
+
+output "region" {
+  description = "The region for running the scheduler and workflow"
+  value       = var.region
+}

--- a/modules/backup/templates/export.yaml.tftpl
+++ b/modules/backup/templates/export.yaml.tftpl
@@ -17,8 +17,10 @@ main:
   - collectInfos:
       assign:
         - backupTime: $${string(int(sys.now()))}
+        - statusMessage: false
+        - statusResult: "start"
 
-  - create new export:
+  - createExport:
       call: http.post
       args:
         url: https://redis.googleapis.com/v1/projects/${project}/locations/${region}/instances/${instanceName}:export
@@ -28,3 +30,32 @@ main:
           outputConfig:
             gcsDestination:
               uri: $${"${gcsBucket}/${instanceName}-" + backupTime + ".rdb"}
+      result: createResult
+      next: checkCondition
+
+  - checkCondition:
+      switch:
+        - condition: $${statusMessage == false}
+          next: checkExportStatus
+      next: returnResult
+
+  - returnResult:
+      return: 'Export process finished'
+  
+  - checkExportStatus:
+      steps:
+        - wait:
+            call: sys.sleep
+            args:
+                seconds: 30
+        - callExportStatus:
+            call: http.get
+            args:
+              url: $${"https://redis.googleapis.com/v1/" + createResult.body.name}
+              auth:
+                type: OAuth2
+            result: statusResult
+        - assignStatus:
+            assign:
+              - statusMessage: $${statusResult.body.done}
+            next: checkCondition

--- a/modules/backup/templates/export.yaml.tftpl
+++ b/modules/backup/templates/export.yaml.tftpl
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+main:
+  steps:
+  - collectInfos:
+      assign:
+        - backupTime: $${string(int(sys.now()))}
+
+  - create new export:
+      call: http.post
+      args:
+        url: https://redis.googleapis.com/v1/projects/${project}/locations/${region}/instances/${instanceName}:export
+        auth:
+          type: OAuth2
+        body:
+          outputConfig:
+            gcsDestination:
+              uri: $${"${gcsBucket}/${instanceName}-" + backupTime + ".rdb"}

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "region" {
+  description = "The region where to run the workflow"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "service_account" {
+  description = "The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that"
+  type        = string
+  default     = null
+}
+
+variable "project_id" {
+  description = "The project ID"
+  type        = string
+}
+
+variable "redis_instance" {
+  description = "The name of the REDIS instance to backup"
+  type        = string
+}
+
+variable "backup_retention_time" {
+  description = "The number of days backups should be kept"
+  type        = number
+  default     = 30
+}
+
+variable "scheduler_timezone" {
+  description = "The Timezone in which the Scheduler Jobs are triggered"
+  type        = string
+  default     = "Etc/GMT"
+}
+
+variable "export_schedule" {
+  description = "The cron schedule to execute the export to GCS"
+  type        = string
+  default     = "15 3 * * *"
+}
+
+variable "export_uri" {
+  description = "The bucket and path uri for exporting to GCS"
+  type        = string
+  validation {
+    condition     = can(regex("^gs:\\/\\/", var.export_uri))
+    error_message = "Must be a full GCS URI starting with gs://."
+  }
+}

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0, < 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Hello!

here a proposal to add a backup TF module.

It's highly inspired by the existing backup module for cloudSQL.

I already use it on my side and sounds working well for now!

Workflow got to be more complex than the cloudSQL one like there is no direct workflow connector to redis, therefore I do some http call to the standard API. The export api request just trigger the export and let redis instance manage the export. So I got to add a loop logic to check status of the running operation to have the correct information on workflow side.