### PR TITLE
fix: Remove maintenance_schedule from ignore_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "google_redis_instance" "default" {
   }
 
   lifecycle {
-    ignore_changes = [maintenance_schedule]
+    ignore_changes = []
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.38.0, < 5.0"
+      version = ">= 4.38.0, < 6.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.38.0, < 6.0"
+      version = ">= 4.0.0, < 6"
     }
   }
 


### PR DESCRIPTION
Hello,

I've addressed the following warning in this PR:

```plaintext
│ Warning: Redundant ignore_changes element
│ 
│   on .terraform/modules/memorystore/memorystore/main.tf line 17, in resource "google_redis_instance" "default":
│   17: resource "google_redis_instance" "default" {
│ 
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value
│ originally configured.
│ 
│ The attribute maintenance_schedule is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in
│ ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
