### PR TITLE
Fix: Ignore maintenance_schedule plan changes, adding fix for warning/ reverting change #152

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,6 @@ resource "google_redis_instance" "default" {
       rdb_snapshot_period = persistence_config.value["rdb_snapshot_period"]
     }
   }
-
-  lifecycle {
-    ignore_changes = [maintenance_schedule]
-  }
 }
 
 module "enable_apis" {


### PR DESCRIPTION
Related issue: https://github.com/terraform-google-modules/terraform-google-memorystore/issues/166
Reverts https://github.com/terraform-google-modules/terraform-google-memorystore/pull/152

This has the updated provider versions.

