### PR TITLE
feat: Add new output called env_vars for Redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ module "memorystore" {
 |------|-------------|
 | auth\_string | AUTH String set on the instance. This field will only be populated if auth\_enabled is true. |
 | current\_location\_id | The current zone where the Redis endpoint is placed. |
+| env\_vars | Exported environment variables |
 | host | The IP address of the instance. |
 | id | The memorystore instance ID. |
 | persistence\_iam\_identity | Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time |

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -17,7 +17,7 @@
 module "redis_cluster" {
   source  = "terraform-google-modules/memorystore/google//modules/redis-cluster"
   version = "~> 9.0"
-  
+
   name      = "test-redis-cluster"
   project   = var.project_id
   region    = "us-central1"

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -15,6 +15,7 @@ This test will create a new redis instance.
 |------|-------------|
 | output\_auth\_string | n/a |
 | output\_current\_location\_id | n/a |
+| output\_env\_vars | n/a |
 | output\_host | n/a |
 | output\_id | n/a |
 | output\_region | n/a |

--- a/examples/redis/outputs.tf
+++ b/examples/redis/outputs.tf
@@ -38,3 +38,7 @@ output "output_auth_string" {
   value     = module.memstore.auth_string
   sensitive = true
 }
+
+output "output_env_vars" {
+  value = module.memstore.env_vars
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -53,6 +53,12 @@ spec:
     description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
     type: string
     required: false
+    connections:
+    - source:
+        source: https://github.com/terraform-google-modules/terraform-google-network//modules/vpc
+        version: v9.1.0
+      spec:
+        output_expr: network_name
   - name: connect_mode
     description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,150 +19,156 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
-  title: ""
-  source:
-    repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
-    sourceType: git
-  version: 9.0.0
-  actuationTool:
-    type: Terraform
-    version: '>= 0.13'
-  subBlueprints:
-  - name: memcache
-    location: modules/memcache
-  examples:
-  - name: basic
-    location: examples/basic
-  - name: memcache
-    location: examples/memcache
-  - name: minimal
-    location: examples/minimal
-  - name: redis
-    location: examples/redis
-  variables:
-  - name: alternative_location_id
-    description: The alternative zone where the instance will be provisioned.
-    type: string
-    required: false
-  - name: auth_enabled
-    description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
-    type: bool
-    default: false
-    required: false
-  - name: authorized_network
-    description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
-    type: string
-    required: false
-  - name: connect_mode
-    description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
-    type: string
-    required: false
-  - name: customer_managed_key
-    description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
-    type: string
-    required: false
-  - name: display_name
-    description: An arbitrary and optional user-provided name for the instance.
-    type: string
-    required: false
-  - name: enable_apis
-    description: Flag for enabling redis.googleapis.com in your project
-    type: bool
-    default: true
-    required: false
-  - name: labels
-    description: The resource labels to represent user provided metadata.
-    type: map(string)
-    required: false
-  - name: location_id
-    description: The zone where the instance will be provisioned. If not provided, the service will choose a zone for the instance. For STANDARD_HA tier, instances will be created across two zones for protection against zonal failures. If [alternativeLocationId] is also provided, it must be different from [locationId].
-    type: string
-    required: false
-  - name: maintenance_policy
-    description: The maintenance policy for an instance.
-    type: |-
-      object({
-          day = string
-          start_time = object({
-            hours   = number
-            minutes = number
-            seconds = number
-            nanos   = number
-          })
-        })
-    required: false
-  - name: memory_size_gb
-    description: Redis memory size in GiB. Defaulted to 1 GiB
-    type: number
-    default: 1
-    required: false
-  - name: name
-    description: The ID of the instance or a fully qualified identifier for the instance.
-    type: string
-    required: true
-  - name: project
-    description: The ID of the project in which the resource belongs to.
-    type: string
-    required: true
-  - name: read_replicas_mode
-    description: 'Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode '
-    type: string
-    default: READ_REPLICAS_DISABLED
-    required: false
-  - name: redis_configs
-    description: The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs)
-    type: map(any)
-    default: {}
-    required: false
-  - name: redis_version
-    description: The version of Redis software.
-    type: string
-    required: false
-  - name: region
-    description: The GCP region to use.
-    type: string
-    required: false
-  - name: replica_count
-    description: The number of replicas. can
-    type: number
-    required: false
-  - name: reserved_ip_range
-    description: The CIDR range of internal addresses that are reserved for this instance.
-    type: string
-    required: false
-  - name: tier
-    description: The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier
-    type: string
-    default: STANDARD_HA
-    required: false
-  - name: transit_encryption_mode
-    description: The TLS mode of the Redis instance, If not provided, TLS is enabled for the instance.
-    type: string
-    default: SERVER_AUTHENTICATION
-    required: false
-  outputs:
-  - name: auth_string
-    description: AUTH String set on the instance. This field will only be populated if auth_enabled is true.
-  - name: current_location_id
-    description: The current zone where the Redis endpoint is placed.
-  - name: host
-    description: The IP address of the instance.
-  - name: id
-    description: The memorystore instance ID.
-  - name: persistence_iam_identity
-    description: Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time
-  - name: port
-    description: The port number of the exposed Redis endpoint.
-  - name: region
-    description: The region the instance lives in.
-  - name: server_ca_certs
-    description: List of server CA certificates for the instance
-  roles:
-  - level: Project
+  info:
+    source:
+      repo: https://github.com/q2w/terraform-google-memorystore.git
+      sourceType: git
+    version: 9.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: memcache
+        location: modules/memcache
+      - name: redis-cluster
+        location: modules/redis-cluster
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: alternative_location_id
+        description: The alternative zone where the instance will be provisioned.
+        varType: string
+      - name: auth_enabled
+        description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
+        varType: bool
+        defaultValue: false
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+      - name: connect_mode
+        description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
+        varType: string
+      - name: customer_managed_key
+        description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
+        varType: string
+      - name: display_name
+        description: An arbitrary and optional user-provided name for the instance.
+        varType: string
+      - name: enable_apis
+        description: Flag for enabling redis.googleapis.com in your project
+        varType: bool
+        defaultValue: true
+      - name: labels
+        description: The resource labels to represent user provided metadata.
+        varType: map(string)
+      - name: location_id
+        description: The zone where the instance will be provisioned. If not provided, the service will choose a zone for the instance. For STANDARD_HA tier, instances will be created across two zones for protection against zonal failures. If [alternativeLocationId] is also provided, it must be different from [locationId].
+        varType: string
+      - name: maintenance_policy
+        description: The maintenance policy for an instance.
+        varType: |-
+          object({
+              day = string
+              start_time = object({
+                hours   = number
+                minutes = number
+                seconds = number
+                nanos   = number
+              })
+            })
+      - name: memory_size_gb
+        description: Redis memory size in GiB. Defaulted to 1 GiB
+        varType: number
+        defaultValue: 1
+      - name: name
+        description: The ID of the instance or a fully qualified identifier for the instance.
+        varType: string
+        required: true
+      - name: persistence_config
+        description: The Redis persistence configuration parameters. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#persistenceconfig
+        varType: |-
+          object({
+              persistence_mode    = string
+              rdb_snapshot_period = string
+            })
+      - name: project
+        description: The ID of the project in which the resource belongs to.
+        varType: string
+        required: true
+      - name: read_replicas_mode
+        description: "Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode "
+        varType: string
+        defaultValue: READ_REPLICAS_DISABLED
+      - name: redis_configs
+        description: The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs)
+        varType: map(any)
+        defaultValue: {}
+      - name: redis_version
+        description: The version of Redis software.
+        varType: string
+      - name: region
+        description: The GCP region to use.
+        varType: string
+      - name: replica_count
+        description: The number of replicas. can
+        varType: number
+      - name: reserved_ip_range
+        description: The CIDR range of internal addresses that are reserved for this instance.
+        varType: string
+      - name: secondary_ip_range
+        description: Optional. Additional IP range for node placement. Required when enabling read replicas on an existing instance.
+        varType: string
+      - name: tier
+        description: The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier
+        varType: string
+        defaultValue: STANDARD_HA
+      - name: transit_encryption_mode
+        description: The TLS mode of the Redis instance, If not provided, TLS is enabled for the instance.
+        varType: string
+        defaultValue: SERVER_AUTHENTICATION
+    outputs:
+      - name: auth_string
+        description: AUTH String set on the instance. This field will only be populated if auth_enabled is true.
+      - name: current_location_id
+        description: The current zone where the Redis endpoint is placed.
+      - name: env_vars
+        description: Exported environment variables
+      - name: host
+        description: The IP address of the instance.
+      - name: id
+        description: The memorystore instance ID.
+      - name: persistence_iam_identity
+        description: Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time
+      - name: port
+        description: The port number of the exposed Redis endpoint.
+      - name: read_endpoint
+        description: " The IP address of the exposed readonly Redis endpoint."
+      - name: region
+        description: The region the instance lives in.
+      - name: server_ca_certs
+        description: List of server CA certificates for the instance
+  requirements:
     roles:
-    - roles/owner
-  services:
-  - cloudresourcemanager.googleapis.com
-  - serviceusage.googleapis.com
-  - redis.googleapis.com
-  - memcache.googleapis.com
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -53,12 +53,6 @@ spec:
     description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
     type: string
     required: false
-    connections:
-    - source:
-        source: https://github.com/terraform-google-modules/terraform-google-network//modules/vpc
-        version: v9.1.0
-      spec:
-        output_expr: network_name
   - name: connect_mode
     description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   info:
     source:
-      repo: https://github.com/q2w/terraform-google-memorystore.git
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
       sourceType: git
     version: 9.0.0
     actuationTool:

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,106 +19,109 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
-  title: ""
-  source:
-    repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
-    sourceType: git
-  version: 9.0.0
-  actuationTool:
-    type: Terraform
-    version: '>= 0.13'
-  examples:
-  - name: basic
-    location: examples/basic
-  - name: memcache
-    location: examples/memcache
-  - name: minimal
-    location: examples/minimal
-  - name: redis
-    location: examples/redis
-  variables:
-  - name: authorized_network
-    description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
-    type: string
-    required: false
-  - name: cpu_count
-    description: Number of CPUs per node
-    type: number
-    default: 1
-    required: false
-  - name: display_name
-    description: An arbitrary and optional user-provided name for the instance.
-    type: string
-    required: false
-  - name: enable_apis
-    description: Flag for enabling memcache.googleapis.com in your project
-    type: bool
-    default: true
-    required: false
-  - name: labels
-    description: The resource labels to represent user provided metadata.
-    type: map(string)
-    default: {}
-    required: false
-  - name: maintenance_policy
-    description: The maintenance policy for an instance.
-    type: |-
-      object({
-          day      = string
-          duration = number
-          start_time = object({
-            hours   = number
-            minutes = number
-            seconds = number
-            nanos   = number
-          })
-        })
-    required: false
-  - name: memory_size_mb
-    description: Memcache memory size in MiB. Defaulted to 1024
-    type: number
-    default: 1024
-    required: false
-  - name: name
-    description: The ID of the instance or a fully qualified identifier for the instance.
-    type: string
-    required: true
-  - name: node_count
-    description: Number of nodes in the memcache instance.
-    type: number
-    default: 1
-    required: false
-  - name: params
-    description: Parameters for the memcache process
-    type: map(string)
-    required: false
-  - name: project
-    description: The ID of the project in which the resource belongs to.
-    type: string
-    required: true
-  - name: region
-    description: The GCP region to use.
-    type: string
-    required: true
-  - name: zones
-    description: Zones where memcache nodes should be provisioned. If not provided, all zones will be used.
-    type: list(string)
-    required: false
-  outputs:
-  - name: discovery
-    description: The memorystore discovery endpoint.
-  - name: id
-    description: The memorystore instance ID.
-  - name: nodes
-    description: Data about the memcache nodes
-  - name: region
-    description: The region the instance lives in.
-  roles:
-  - level: Project
+  info:
+    source:
+      repo: https://github.com/q2w/terraform-google-memorystore.git
+      sourceType: git
+      dir: /modules/memcache
+    version: 9.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+      - name: cpu_count
+        description: Number of CPUs per node
+        varType: number
+        defaultValue: 1
+      - name: display_name
+        description: An arbitrary and optional user-provided name for the instance.
+        varType: string
+      - name: enable_apis
+        description: Flag for enabling memcache.googleapis.com in your project
+        varType: bool
+        defaultValue: true
+      - name: labels
+        description: The resource labels to represent user provided metadata.
+        varType: map(string)
+        defaultValue: {}
+      - name: maintenance_policy
+        description: The maintenance policy for an instance.
+        varType: |-
+          object({
+              day      = string
+              duration = string
+              start_time = object({
+                hours   = number
+                minutes = number
+                seconds = number
+                nanos   = number
+              })
+            })
+      - name: memcache_version
+        description: The major version of Memcached software.
+        varType: string
+      - name: memory_size_mb
+        description: Memcache memory size in MiB. Defaulted to 1024
+        varType: number
+        defaultValue: 1024
+      - name: name
+        description: The ID of the instance or a fully qualified identifier for the instance.
+        varType: string
+        required: true
+      - name: node_count
+        description: Number of nodes in the memcache instance.
+        varType: number
+        defaultValue: 1
+      - name: params
+        description: Parameters for the memcache process
+        varType: map(string)
+      - name: project
+        description: The ID of the project in which the resource belongs to.
+        varType: string
+        required: true
+      - name: region
+        description: The GCP region to use.
+        varType: string
+        required: true
+      - name: zones
+        description: Zones where memcache nodes should be provisioned. If not provided, all zones will be used.
+        varType: list(string)
+    outputs:
+      - name: discovery
+        description: The memorystore discovery endpoint.
+      - name: id
+        description: The memorystore instance ID.
+      - name: nodes
+        description: Data about the memcache nodes
+      - name: region
+        description: The region the instance lives in.
+  requirements:
     roles:
-    - roles/owner
-  services:
-  - cloudresourcemanager.googleapis.com
-  - serviceusage.googleapis.com
-  - redis.googleapis.com
-  - memcache.googleapis.com
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   info:
     source:
-      repo: https://github.com/q2w/terraform-google-memorystore.git
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
       sourceType: git
       dir: /modules/memcache
     version: 9.0.0

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -22,7 +22,7 @@ spec:
   info:
     title: Memorystore Redis Cluster Terraform Module
     source:
-      repo: https://github.com/q2w/terraform-google-memorystore.git
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
       sourceType: git
       dir: /modules/redis-cluster
     version: 9.0.0

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -1,0 +1,130 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-memorystore
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Memorystore Redis Cluster Terraform Module
+    source:
+      repo: https://github.com/q2w/terraform-google-memorystore.git
+      sourceType: git
+      dir: /modules/redis-cluster
+    version: 9.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
+    description: {}
+  content:
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: authorization_mode
+        description: "The authorization mode of the Redis cluster. If not provided, auth feature is disabled for the cluster. Default value is AUTH_MODE_DISABLED. Possible values are: AUTH_MODE_UNSPECIFIED, AUTH_MODE_IAM_AUTH, AUTH_MODE_DISABLED"
+        varType: string
+        defaultValue: AUTH_MODE_DISABLED
+      - name: enable_apis
+        description: Flag for enabling memcache.googleapis.com in your project
+        varType: bool
+        defaultValue: true
+      - name: name
+        description: The ID of the instance or a fully qualified identifier for the instance. must be 1 to 63 characters and use only lowercase letters, numbers, or hyphens. It must start with a lowercase letter and end with a lowercase letter or number
+        varType: string
+        required: true
+      - name: network
+        description: List of consumer network where the network address of the discovery endpoint will be reserved, in the form of projects/{network_project_id_or_number}/global/networks/{network_id}. Currently, only one item is supported
+        varType: list(string)
+        required: true
+      - name: node_type
+        description: "The nodeType for the Redis cluster. If not provided, REDIS_HIGHMEM_MEDIUM will be used as default Possible values are: REDIS_SHARED_CORE_NANO, REDIS_HIGHMEM_MEDIUM, REDIS_HIGHMEM_XLARGE, REDIS_STANDARD_SMALL."
+        varType: string
+      - name: project
+        description: The ID of the project in which the resource belongs to.
+        varType: string
+        required: true
+      - name: redis_configs
+        description: Configure Redis Cluster behavior using a subset of native Redis configuration parameters
+        varType: |-
+          object({
+              maxmemory-clients       = optional(string)
+              maxmemory               = optional(string)
+              maxmemory-policy        = optional(string)
+              notify-keyspace-events  = optional(string)
+              slowlog-log-slower-than = optional(number)
+              maxclients              = optional(number)
+            })
+      - name: region
+        description: The name of the region of the Redis cluster
+        varType: string
+        required: true
+      - name: replica_count
+        description: The number of replica nodes per shard. Each shard can have 0, 1, or 2 replica nodes. Replicas provide high availability and additional read throughput, and are evenly distributed across zones
+        varType: number
+        defaultValue: 0
+      - name: service_connection_policies
+        description: The Service Connection Policies to create
+        varType: |-
+          map(object({
+              description     = optional(string)
+              network_name    = string
+              network_project = string
+              subnet_names    = list(string)
+              limit           = optional(number)
+              labels          = optional(map(string), {})
+            }))
+        defaultValue: {}
+      - name: shard_count
+        description: Required. Number of shards for the Redis cluster. The minimum number of shards in a Memorystore cluster is 3 shards
+        varType: number
+        defaultValue: 3
+      - name: transit_encryption_mode
+        description: "The in-transit encryption for the Redis cluster. If not provided, encryption is disabled for the cluster. Default value is TRANSIT_ENCRYPTION_MODE_DISABLED. Possible values are: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED, TRANSIT_ENCRYPTION_MODE_DISABLED, TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"
+        varType: string
+        defaultValue: TRANSIT_ENCRYPTION_MODE_DISABLED
+    outputs:
+      - name: discovery_endpoints
+        description: Endpoints created on each given network, for Redis clients to connect to the cluster. Currently only one endpoint is supported
+      - name: id
+        description: The redis cluster instance ID
+      - name: psc_connections
+        description: PSC connections for discovery of the cluster topology and accessing the cluster
+      - name: redis_cluster
+        description: The redis cluster created
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,5 +63,8 @@ output "server_ca_certs" {
 
 output "env_vars" {
   description = "Exported environment variables"
-  value = { "REDIS_HOST": google_redis_instance.default.host, "REDIS_PORT": google_redis_instance.default.port}
+  value = {
+    "REDIS_HOST" : google_redis_instance.default.host,
+    "REDIS_PORT" : google_redis_instance.default.port
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,3 +60,8 @@ output "server_ca_certs" {
   value       = google_redis_instance.default.server_ca_certs
   sensitive   = false
 }
+
+output "env_vars" {
+  description = "Exported environment variables"
+  value = { "REDIS_HOST": google_redis_instance.default.host, "REDIS_PORT": google_redis_instance.default.port}
+}

--- a/test/integration/redis-cluster/redis_cluster_test.go
+++ b/test/integration/redis-cluster/redis_cluster_test.go
@@ -26,8 +26,6 @@ func TestRedisCluster(t *testing.T) {
 	rc := tft.NewTFBlueprintTest(t)
 
 	rc.DefineVerify(func(assert *assert.Assertions) {
-		rc.DefaultVerify(assert)
-
 		projectId := rc.GetStringOutput("project_id")
 		clusterName := rc.GetStringOutput("cluster_name")
 		clusterRegion := rc.GetStringOutput("cluster_region")
@@ -38,8 +36,7 @@ func TestRedisCluster(t *testing.T) {
 		authorizationMode := rc.GetStringOutput("authorization_mode")
 		nodeType := rc.GetStringOutput("node_type")
 
-
-		op := gcloud.Runf(t, "redis clusters describe %s --project %s --region %s",clusterName, projectId, clusterRegion)
+		op := gcloud.Runf(t, "redis clusters describe %s --project %s --region %s", clusterName, projectId, clusterRegion)
 		assert.Equal(op.Get("name").String(), clusterId)
 		assert.Equal(op.Get("shardCount").String(), shardCount)
 		assert.Equal(op.Get("transitEncryptionMode").String(), transitEncryptionMode)

--- a/test/integration/redis/redis_test.go
+++ b/test/integration/redis/redis_test.go
@@ -29,11 +29,14 @@ func TestRedis(t *testing.T) {
 		bpt.DefaultVerify(assert)
 
 		projectId := bpt.GetStringOutput("project_id")
+		envVars := bpt.GetStringOutput("output_env_vars")
 
 		op := gcloud.Runf(t, "redis instances describe test-redis --project=%s --region=us-east1", projectId)
 		assert.True(op.Get("authEnabled").Bool())
 		assert.Equal(op.Get("memorySizeGb").String(), "1")
 		assert.Equal(op.Get("transitEncryptionMode").String(), "SERVER_AUTHENTICATION")
+		assert.Contains(envVars, "REDIS_HOST")
+		assert.Contains(envVars, "REDIS_PORT")
 	})
 
 	bpt.Test()


### PR DESCRIPTION
This PR makes below changes,

1. Add new output called env_vars for Redis
2. Update metadata files using `make generate_docs`