### PR TITLE
chore: add connection metadata and output type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.21
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
-	  -e ENABLE_BPMETADATA \
+		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh
@@ -77,7 +77,6 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
-		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
+	  -e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# [Google Cloud Memorystore Terraform Module](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/)
+# Google Cloud Memorystore Terraform Module
+[terraform registry](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/)
 
 A Terraform module for creating a fully functional Google Memorystore Redis instance. For Memcache and Redis Cluster see [sub-modules](./modules/)
 

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -16,7 +16,7 @@
 
 module "memstore" {
   source  = "terraform-google-modules/memorystore/google"
-  version = "~> 9.0"
+  version = "~> 10.0"
 
   name = "test-redis"
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -153,8 +153,7 @@ spec:
         type: string
       - name: env_vars
         description: Exported environment variables
-        type:  |
-        [
+        type: [
           "object",
           {
             "REDIS_HOST": "string",
@@ -181,8 +180,7 @@ spec:
         type: string
       - name: server_ca_certs
         description: List of server CA certificates for the instance
-        type: |
-        [
+        type: [
           "list",
           [
             "object",
@@ -198,7 +196,7 @@ spec:
   requirements:
     provider_versions:
       - source: hashicorp/google
-        version: >= 4.74.0, < 6
+        version: ">= 4.74.0, < 6"
     roles:
       - level: Project
         roles:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,6 +20,7 @@ metadata:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
+    title: Google Cloud Memorystore Terraform Module
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
       sourceType: git
@@ -62,7 +63,7 @@ spec:
             source: https://github.com/terraform-google-modules/terraform-google-network//modules/vpc
             version: v9.1.0
           spec:
-            output_expr: network_name        
+            outputExpr: network_name
       - name: connect_mode
         description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
         varType: string
@@ -194,9 +195,6 @@ spec:
           ]
         ]
   requirements:
-    provider_versions:
-      - source: hashicorp/google
-        version: ">= 4.74.0, < 6"
     roles:
       - level: Project
         roles:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -57,6 +57,12 @@ spec:
       - name: authorized_network
         description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
         varType: string
+        connections:
+        - source:
+            source: https://github.com/terraform-google-modules/terraform-google-network//modules/vpc
+            version: v9.1.0
+          spec:
+            output_expr: network_name        
       - name: connect_mode
         description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
         varType: string
@@ -141,25 +147,58 @@ spec:
     outputs:
       - name: auth_string
         description: AUTH String set on the instance. This field will only be populated if auth_enabled is true.
+        type: string
       - name: current_location_id
         description: The current zone where the Redis endpoint is placed.
+        type: string
       - name: env_vars
         description: Exported environment variables
+        type:  |
+        [
+          "object",
+          {
+            "REDIS_HOST": "string",
+            "REDIS_PORT": "number"
+          }
+        ]
       - name: host
         description: The IP address of the instance.
+        type: string
       - name: id
         description: The memorystore instance ID.
+        type: string
       - name: persistence_iam_identity
         description: Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time
+        type: string
       - name: port
         description: The port number of the exposed Redis endpoint.
+        type: number
       - name: read_endpoint
         description: " The IP address of the exposed readonly Redis endpoint."
+        type: string
       - name: region
         description: The region the instance lives in.
+        type: string
       - name: server_ca_certs
         description: List of server CA certificates for the instance
+        type: |
+        [
+          "list",
+          [
+            "object",
+            {
+              "cert": "string",
+              "create_time": "string",
+              "expire_time": "string",
+              "serial_number": "string",
+              "sha1_fingerprint": "string"
+            }
+          ]
+        ]
   requirements:
+    provider_versions:
+      - source: hashicorp/google
+        version: >= 4.74.0, < 6
     roles:
       - level: Project
         roles:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,7 +60,7 @@ spec:
         varType: string
         connections:
         - source:
-            source: https://github.com/terraform-google-modules/terraform-google-network//modules/vpc
+            source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
             version: v9.1.0
           spec:
             outputExpr: network_name

--- a/modules/memcache/README.md
+++ b/modules/memcache/README.md
@@ -1,4 +1,5 @@
-# [Google Cloud Memorystore Terraform Module](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/)
+# Google Cloud Memorystore Terraform Module
+[terraform registry](https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/)
 
 A Terraform module for creating a fully functional Google Memorystore (memcache) instance.
 

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -20,6 +20,7 @@ metadata:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
+    title: Google Cloud Memorystore Terraform Module
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
       sourceType: git

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -106,6 +106,13 @@ spec:
         description: "The in-transit encryption for the Redis cluster. If not provided, encryption is disabled for the cluster. Default value is TRANSIT_ENCRYPTION_MODE_DISABLED. Possible values are: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED, TRANSIT_ENCRYPTION_MODE_DISABLED, TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"
         varType: string
         defaultValue: TRANSIT_ENCRYPTION_MODE_DISABLED
+      - name: zone_distribution_config_mode
+        description: "The mode for zone distribution for Memorystore Redis cluster (Immutable). If not provided, MULTI_ZONE will be used as default value. Possible values are: MULTI_ZONE, SINGLE_ZONE"
+        varType: string
+        defaultValue: MULTI_ZONE
+      - name: zone_distribution_config_zone
+        description: The zone for single zone Memorystore Redis cluster (Immutable)
+        varType: string
     outputs:
       - name: discovery_endpoints
         description: Endpoints created on each given network, for Redis clients to connect to the cluster. Currently only one endpoint is supported


### PR DESCRIPTION
This PR makes below changes,

1. Adds connection metadata manually to metadata.yaml
2. Adds output type manually to metadata.yaml