### PR TITLE
fix: Bump google-project-factory to ~> 17.0 for compatibility with google provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "google_redis_instance" "default" {
 
 module "enable_apis" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 15.0"
+  version = "~> 17.0"
 
   project_id                  = var.project
   enable_apis                 = var.enable_apis

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ spec:
     version: 11.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     subBlueprints:
@@ -59,11 +59,11 @@ spec:
         description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
         varType: string
         connections:
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
-            version: v9.1.0
-          spec:
-            outputExpr: network_name
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
+              version: v9.1.0
+            spec:
+              outputExpr: network_name
       - name: connect_mode
         description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
         varType: string
@@ -148,52 +148,24 @@ spec:
     outputs:
       - name: auth_string
         description: AUTH String set on the instance. This field will only be populated if auth_enabled is true.
-        type: string
       - name: current_location_id
         description: The current zone where the Redis endpoint is placed.
-        type: string
       - name: env_vars
         description: Exported environment variables
-        type: [
-          "object",
-          {
-            "REDIS_HOST": "string",
-            "REDIS_PORT": "number"
-          }
-        ]
       - name: host
         description: The IP address of the instance.
-        type: string
       - name: id
         description: The memorystore instance ID.
-        type: string
       - name: persistence_iam_identity
         description: Cloud IAM identity used by import/export operations. Format is 'serviceAccount:'. May change over time
-        type: string
       - name: port
         description: The port number of the exposed Redis endpoint.
-        type: number
       - name: read_endpoint
         description: " The IP address of the exposed readonly Redis endpoint."
-        type: string
       - name: region
         description: The region the instance lives in.
-        type: string
       - name: server_ca_certs
         description: List of server CA certificates for the instance
-        type: [
-          "list",
-          [
-            "object",
-            {
-              "cert": "string",
-              "create_time": "string",
-              "expire_time": "string",
-              "serial_number": "string",
-              "sha1_fingerprint": "string"
-            }
-          ]
-        ]
   requirements:
     roles:
       - level: Project
@@ -207,3 +179,6 @@ spec:
       - serviceconsumermanagement.googleapis.com
       - networkconnectivity.googleapis.com
       - compute.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 4.74.0, < 7"

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 11.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -126,3 +126,6 @@ spec:
       - serviceconsumermanagement.googleapis.com
       - networkconnectivity.googleapis.com
       - compute.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 4.74.0, < 7"

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -48,6 +48,10 @@ spec:
         description: "The authorization mode of the Redis cluster. If not provided, auth feature is disabled for the cluster. Default value is AUTH_MODE_DISABLED. Possible values are: AUTH_MODE_UNSPECIFIED, AUTH_MODE_IAM_AUTH, AUTH_MODE_DISABLED"
         varType: string
         defaultValue: AUTH_MODE_DISABLED
+      - name: deletion_protection_enabled
+        description: " Indicates if the cluster is deletion protected or not. If the value if set to true, any delete cluster operation will fail. Default value is true"
+        varType: bool
+        defaultValue: true
       - name: enable_apis
         description: Flag for enabling memcache.googleapis.com in your project
         varType: bool
@@ -135,3 +139,6 @@ spec:
       - serviceconsumermanagement.googleapis.com
       - networkconnectivity.googleapis.com
       - compute.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 4.74.0, < 7"


### PR DESCRIPTION

The google provider was bumped in https://github.com/terraform-google-modules/terraform-google-memorystore/pull/229. However, the `enable_apis` module still has a < 6.0 constraint. These are in conflict. This issue was encountered when bumping from 8.0.0 -> 11.0.0.


- This introduced hashicorp/google 6.* support https://github.com/terraform-google-modules/terraform-google-project-factory/pull/939

