### PR TITLE
fix: Broken module due to apphub_service_uri output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -72,7 +72,7 @@ output "env_vars" {
 output "apphub_service_uri" {
   value = {
     service_uri = "//redis.googleapis.com/${google_redis_instance.default.id}"
-    service_id  = substr("${var.name}-${md5("${var.region}-${var.project_id}")}", 0, 63)
+    service_id  = substr("${var.name}-${md5("${google_redis_instance.default.region}-${var.project_id}")}", 0, 63)
   }
   description = "Service URI in CAIS style to be used by Apphub."
 }


### PR DESCRIPTION
The latest addition to the output, `apphub_service_uri`, breaks the module due to the use of `var.region` which isn't a required variable and defaults to `null`.

Getting the region from the `google_redis_instance` resource instead will fix this.

```
│ Error: Invalid template interpolation value
│
│   on .terraform/modules/redis/outputs.tf line 75, in output "apphub_service_uri":
│   75:     service_id  = substr("${var.name}-${md5("${var.region}-${var.project_id}")}", 0, 63)
│     ├────────────────
│     │ var.region is null
│
│ The expression result is null. Cannot include a null value in a string template.
```

fixes #247 