### PR TITLE
fix!: remove apphub_service_uri output and update metadata display yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ module "memorystore" {
 
 | Name | Description |
 |------|-------------|
-| apphub\_service\_uri | Service URI in CAIS style to be used by Apphub. |
 | auth\_string | AUTH String set on the instance. This field will only be populated if auth\_enabled is true. |
 | current\_location\_id | The current zone where the Redis endpoint is placed. |
 | env\_vars | Exported environment variables |

--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -1,0 +1,14 @@
+# Upgrading to v13.0
+
+The v13.0 release contains backwards-incompatible changes.
+
+## Replace uses of apphub_service_uri
+
+This release removes apphub_service_uri output. You can replace use of `apphub_service_uri` by forming the desired output as below,
+
+```
+{
+    service_uri = "//redis.googleapis.com/${module.memorystore.id}"
+    service_id  = substr("${<redis-instance-name>}-${md5(${module.memorystore.id})}", 0, 63)
+}
+```

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -36,18 +36,18 @@ spec:
         authorized_network:
           name: authorized_network
           title: Authorized Network
-          invisible: false
+          level: 1
         connect_mode:
           name: connect_mode
           title: Connect Mode
-          invisible: false
+          level: 1
         customer_managed_key:
           name: customer_managed_key
           title: Customer Managed Key
         display_name:
           name: display_name
           title: Display Name
-          invisible: false
+          level: 1
         enable_apis:
           name: enable_apis
           title: Enable Apis
@@ -63,7 +63,7 @@ spec:
         memory_size_gb:
           name: memory_size_gb
           title: Memory Size Gb
-          invisible: false
+          level: 1
         name:
           name: name
           title: Name
@@ -84,15 +84,15 @@ spec:
         redis_version:
           name: redis_version
           title: Redis Version
-          invisible: false
+          level: 1
         region:
           name: region
           title: Region
-          invisible: false
+          level: 1
         replica_count:
           name: replica_count
           title: Replica Count
-          invisible: false
+          level: 1
         reserved_ip_range:
           name: reserved_ip_range
           title: Reserved Ip Range
@@ -102,7 +102,7 @@ spec:
         tier:
           name: tier
           title: Tier
-          invisible: false
+          level: 1
           enumValueLabels:
             - label: STANDARD_HA
               value: STANDARD_HA

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -52,30 +52,20 @@ spec:
         location: examples/valkey
   interfaces:
     variables:
-      - name: region
-        description: The GCP region to use.
-        varType: string
       - name: project_id
         description: The ID of the project in which the resource belongs to.
         varType: string
         required: true
-      - name: enable_apis
-        description: Flag for enabling redis.googleapis.com in your project
-        varType: bool
-        defaultValue: true
+      - name: region
+        description: The GCP region to use.
+        varType: string
       - name: name
         description: The ID of the instance or a fully qualified identifier for the instance.
         varType: string
         required: true
-      - name: authorized_network
-        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+      - name: display_name
+        description: An arbitrary and optional user-provided name for the instance.
         varType: string
-        connections:
-          - source:
-              source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
-              version: ">= 9.1.0"
-            spec:
-              outputExpr: network_name
       - name: tier
         description: The service tier of the instance. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Tier
         varType: string
@@ -85,8 +75,27 @@ spec:
         varType: number
         defaultValue: 1
       - name: replica_count
-        description: The number of replicas. can
+        description: The number of replicas.
         varType: number
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
+              version: ">= 9.1.0"
+            spec:
+              outputExpr: network_name
+      - name: redis_version
+        description: The version of Redis software.
+        varType: string
+      - name: connect_mode
+        description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
+        varType: string
+      - name: enable_apis
+        description: Flag for enabling redis.googleapis.com in your project
+        varType: bool
+        defaultValue: true
       - name: read_replicas_mode
         description: "Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode "
         varType: string
@@ -97,24 +106,15 @@ spec:
       - name: alternative_location_id
         description: The alternative zone where the instance will be provisioned.
         varType: string
-      - name: redis_version
-        description: The version of Redis software.
-        varType: string
       - name: redis_configs
         description: The Redis configuration parameters. See [more details](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs)
         varType: map(any)
         defaultValue: {}
-      - name: display_name
-        description: An arbitrary and optional user-provided name for the instance.
-        varType: string
       - name: reserved_ip_range
         description: The CIDR range of internal addresses that are reserved for this instance.
         varType: string
       - name: secondary_ip_range
         description: Optional. Additional IP range for node placement. Required when enabling read replicas on an existing instance.
-        varType: string
-      - name: connect_mode
-        description: The connection mode of the Redis instance. Can be either DIRECT_PEERING or PRIVATE_SERVICE_ACCESS. The default connect mode if not provided is DIRECT_PEERING.
         varType: string
       - name: labels
         description: The resource labels to represent user provided metadata.
@@ -150,12 +150,6 @@ spec:
               rdb_snapshot_period = string
             })
     outputs:
-      - name: apphub_service_uri
-        description: Service URI in CAIS style to be used by Apphub.
-        type:
-          - object
-          - service_id: string
-            service_uri: string
       - name: auth_string
         description: AUTH String set on the instance. This field will only be populated if auth_enabled is true.
         type: string

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,11 +68,3 @@ output "env_vars" {
     "REDIS_PORT" : tostring(google_redis_instance.default.port)
   }
 }
-
-output "apphub_service_uri" {
-  value = {
-    service_uri = "//redis.googleapis.com/${google_redis_instance.default.id}"
-    service_id  = substr("${var.name}-${md5("${google_redis_instance.default.region}-${var.project_id}")}", 0, 63)
-  }
-  description = "Service URI in CAIS style to be used by Apphub."
-}


### PR DESCRIPTION
We are removing apphub_service_uri as memorystore is not yet supported by AppHub