### PR TITLE
chore: Update README.md

### DIFF
--- a/modules/redis-cluster/README.md
+++ b/modules/redis-cluster/README.md
@@ -13,7 +13,7 @@ module "redis_cluster" {
   version = "~> 13.3"
 
   name    = "test-redis-cluster"
-  project = var.project_id
+  project_id = var.project_id
   region  = "us-central1"
   network = ["projects/${var.project_id}/global/networks/${var.network_name}"]
   node_type = "REDIS_STANDARD_SMALL"


### PR DESCRIPTION
README had `project` instead of `project_id` under usage. If user used as a reference, two errors would happen.

- The argument "project_id" is required, but no definition was found.

- An argument named "project" is not expected here.