### PR TITLE
Remove redundant "enable_api" module from example

### DIFF
--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -14,25 +14,6 @@
  * limitations under the License.
  */
 
-module "enable_apis" {
-  source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 18.0"
-
-  project_id  = var.project_id
-  enable_apis = true
-
-  disable_services_on_destroy = false
-  disable_dependent_services  = false
-
-  activate_apis = [
-    "redis.googleapis.com",
-    "serviceconsumermanagement.googleapis.com",
-    "networkconnectivity.googleapis.com",
-    "compute.googleapis.com",
-  ]
-}
-
-
 module "redis_cluster_central" {
   source  = "terraform-google-modules/memorystore/google//modules/redis-cluster"
   version = "~> 14.0"


### PR DESCRIPTION
Context:
While exploring the codebase for better understanding, I noticed that the enable_api module was present in both the main.tf file of the examples folder and the modules folder. After confirming with abhiwa@, we concluded that this duplication is redundant.

Rationale:
1. The examples folder is intended to provide a working demonstration of the resources and code, serving as a practical reference for users.
2. Including enable_api in this context adds unnecessary complexity and goes against the purpose of examples.

Impact:
1. Improves clarity for users referring to the examples.
2. Aligns with best practices by maintaining separation of concerns between examples and modules.

Solution:
Removed the enable_api module from the main.tf in the examples folder.

