### PR TITLE
chore: add output types to Redis Cluster's metadata.yaml for ADC compliance

### DIFF
--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -158,14 +144,188 @@ spec:
     outputs:
       - name: discovery_endpoints
         description: Endpoints created on each given network, for Redis clients to connect to the cluster. Currently only one endpoint is supported
+        type:
+          - list
+          - - object
+            - address: string
+              port: number
+              psc_config:
+                - list
+                - - object
+                  - network: string
       - name: id
         description: The redis cluster instance ID
+        type: string
       - name: psc_connections
         description: PSC connections for discovery of the cluster topology and accessing the cluster
+        type:
+          - list
+          - - object
+            - address: string
+              forwarding_rule: string
+              network: string
+              project_id: string
+              psc_connection_id: string
       - name: psc_service_attachments
         description: The PSC service attachments of the cluster
+        type:
+          - list
+          - - object
+            - connection_type: string
+              service_attachment: string
       - name: redis_cluster
         description: The redis cluster created
+        type:
+          - object
+          - authorization_mode: string
+            automated_backup_config:
+              - list
+              - - object
+                - fixed_frequency_schedule:
+                    - list
+                    - - object
+                      - start_time:
+                          - list
+                          - - object
+                            - hours: number
+                  retention: string
+            backup_collection: string
+            create_time: string
+            cross_cluster_replication_config:
+              - list
+              - - object
+                - cluster_role: string
+                  membership:
+                    - list
+                    - - object
+                      - primary_cluster:
+                          - list
+                          - - object
+                            - cluster: string
+                              uid: string
+                        secondary_clusters:
+                          - list
+                          - - object
+                            - cluster: string
+                              uid: string
+                  primary_cluster:
+                    - list
+                    - - object
+                      - cluster: string
+                        uid: string
+                  secondary_clusters:
+                    - list
+                    - - object
+                      - cluster: string
+                        uid: string
+                  update_time: string
+            deletion_protection_enabled: bool
+            discovery_endpoints:
+              - list
+              - - object
+                - address: string
+                  port: number
+                  psc_config:
+                    - list
+                    - - object
+                      - network: string
+            gcs_source:
+              - list
+              - - object
+                - uris:
+                    - set
+                    - string
+            id: string
+            kms_key: string
+            maintenance_policy:
+              - list
+              - - object
+                - create_time: string
+                  update_time: string
+                  weekly_maintenance_window:
+                    - list
+                    - - object
+                      - day: string
+                        duration: string
+                        start_time:
+                          - list
+                          - - object
+                            - hours: number
+                              minutes: number
+                              nanos: number
+                              seconds: number
+            maintenance_schedule:
+              - list
+              - - object
+                - end_time: string
+                  schedule_deadline_time: string
+                  start_time: string
+            managed_backup_source:
+              - list
+              - - object
+                - backup: string
+            name: string
+            node_type: string
+            persistence_config:
+              - list
+              - - object
+                - aof_config:
+                    - list
+                    - - object
+                      - append_fsync: string
+                  mode: string
+                  rdb_config:
+                    - list
+                    - - object
+                      - rdb_snapshot_period: string
+                        rdb_snapshot_start_time: string
+            precise_size_gb: number
+            project: string
+            psc_configs:
+              - list
+              - - object
+                - network: string
+            psc_connections:
+              - list
+              - - object
+                - address: string
+                  forwarding_rule: string
+                  network: string
+                  project_id: string
+                  psc_connection_id: string
+            psc_service_attachments:
+              - list
+              - - object
+                - connection_type: string
+                  service_attachment: string
+            redis_configs:
+              - map
+              - string
+            region: string
+            replica_count: number
+            shard_count: number
+            size_gb: number
+            state: string
+            state_info:
+              - list
+              - - object
+                - update_info:
+                    - list
+                    - - object
+                      - target_replica_count: number
+                        target_shard_count: number
+            timeouts:
+              - object
+              - create: string
+                delete: string
+                update: string
+            transit_encryption_mode: string
+            uid: string
+            zone_distribution_config:
+              - list
+              - - object
+                - mode: string
+                  zone: string
   requirements:
     roles:
       - level: Project


### PR DESCRIPTION
Purpose: This is an essential step in making Redis-cluster's Terraform blueprint ADC compliant. 

This PR adds the type field to all output variables in the Redis Cluster's metadata.yaml.


