### PR TITLE
chore: set visibility of output variables for redis-cluster 

### DIFF
--- a/modules/redis-cluster/metadata.display.yaml
+++ b/modules/redis-cluster/metadata.display.yaml
@@ -94,3 +94,7 @@ spec:
         zone_distribution_config_zone:
           name: zone_distribution_config_zone
           title: Zone Distribution Config Zone
+    runtime:
+      outputs:
+        discovery_endpoints:
+          visibility: VISIBILITY_ROOT


### PR DESCRIPTION
This PR sets the visibility to "VISIBILITY_ROOT" for required output variables in redis-cluster's metadata.display.yaml
Purpose: This is an essential step in making Redis-cluster's Terraform blueprint ADC compliant.
