### PR TITLE
Fix gcs_source to uris transform

### DIFF
--- a/modules/valkey/main.tf
+++ b/modules/valkey/main.tf
@@ -74,7 +74,7 @@ resource "google_memorystore_instance" "valkey_cluster" {
   dynamic "gcs_source" {
     for_each = var.gcs_source != null ? ["gcs_source"] : []
     content {
-      uris = var.gcs_source
+      uris = split(",", var.gcs_source)
     }
   }
 


### PR DESCRIPTION
When creating a new valkey cluster with gcs_source, we are instructed to pass a comma-separated list. However, it's not accepted by the underlying terraform resource. This PR fixes that mismatch 🙏