### PR TITLE
feat: per module requirements configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display --per-module-requirements'
 
 # Alias for backwards compatibility
 .PHONY: generate_docs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -203,6 +203,7 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/compute.networkAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/redis.admin

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -203,23 +203,17 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/memorystore.admin
-          - roles/redis.admin
-          - roles/memcache.admin
-          - roles/compute.networkAdmin
           - roles/resourcemanager.projectIamAdmin
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/redis.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountUser
     services:
       - cloudresourcemanager.googleapis.com
-      - serviceusage.googleapis.com
-      - redis.googleapis.com
+      - iam.googleapis.com
       - memcache.googleapis.com
-      - serviceconsumermanagement.googleapis.com
-      - networkconnectivity.googleapis.com
-      - compute.googleapis.com
-      - memorystore.googleapis.com
-      - cloudkms.googleapis.com
+      - redis.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.74, < 7"

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -123,6 +123,7 @@ spec:
           - roles/redis.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
+          - roles/compute.networkAdmin
     services:
       - memcache.googleapis.com
       - redis.googleapis.com

--- a/modules/memcache/metadata.yaml
+++ b/modules/memcache/metadata.yaml
@@ -119,23 +119,14 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/memorystore.admin
+          - roles/redis.viewer
           - roles/redis.admin
-          - roles/memcache.admin
-          - roles/compute.networkAdmin
-          - roles/resourcemanager.projectIamAdmin
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - serviceusage.googleapis.com
-      - redis.googleapis.com
       - memcache.googleapis.com
-      - serviceconsumermanagement.googleapis.com
-      - networkconnectivity.googleapis.com
-      - compute.googleapis.com
-      - memorystore.googleapis.com
-      - cloudkms.googleapis.com
+      - redis.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.23, < 7"

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -363,23 +363,14 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/memorystore.admin
           - roles/redis.admin
-          - roles/memcache.admin
-          - roles/compute.networkAdmin
-          - roles/resourcemanager.projectIamAdmin
-          - roles/cloudkms.admin
+          - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
     services:
-      - cloudresourcemanager.googleapis.com
-      - serviceusage.googleapis.com
-      - redis.googleapis.com
-      - memcache.googleapis.com
-      - serviceconsumermanagement.googleapis.com
-      - networkconnectivity.googleapis.com
-      - compute.googleapis.com
-      - memorystore.googleapis.com
       - cloudkms.googleapis.com
+      - redis.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 6.22, < 7"

--- a/modules/valkey/metadata.yaml
+++ b/modules/valkey/metadata.yaml
@@ -185,23 +185,14 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/memorystore.admin
-          - roles/redis.admin
-          - roles/memcache.admin
-          - roles/compute.networkAdmin
-          - roles/resourcemanager.projectIamAdmin
-          - roles/cloudkms.admin
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/redis.admin
+          - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - serviceusage.googleapis.com
-      - redis.googleapis.com
-      - memcache.googleapis.com
-      - serviceconsumermanagement.googleapis.com
-      - networkconnectivity.googleapis.com
-      - compute.googleapis.com
-      - memorystore.googleapis.com
       - cloudkms.googleapis.com
+      - redis.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 6.30, < 7"

--- a/modules/valkey/metadata.yaml
+++ b/modules/valkey/metadata.yaml
@@ -185,10 +185,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
           - roles/redis.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
     services:
       - cloudkms.googleapis.com
       - redis.googleapis.com

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -34,6 +34,7 @@ locals {
       "roles/redis.admin",
       "roles/iam.serviceAccountUser",
       "roles/logging.logWriter",
+      "roles/compute.networkAdmin",
     ]
     root = [
       "roles/resourcemanager.projectIamAdmin",

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,15 +15,41 @@
  */
 
 locals {
-  int_required_roles = [
+
+  per_module_roles = {
+    valkey = [
+      "roles/redis.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+    ]
+    redis-cluster = [
+      "roles/redis.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+    ]
+    memcache = [
+      "roles/redis.viewer",
+      "roles/redis.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    root = [
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/redis.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountUser",
+    ]
+  }
+
+  int_required_roles = concat([
     "roles/memorystore.admin",
     "roles/redis.admin",
     "roles/memcache.admin",
-    "roles/compute.networkAdmin",
-    "roles/resourcemanager.projectIamAdmin",
     "roles/cloudkms.admin",
-    "roles/cloudkms.cryptoKeyEncrypterDecrypter",
-  ]
+  ], flatten(values(local.per_module_roles)))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -42,6 +42,7 @@ locals {
       "roles/redis.admin",
       "roles/iam.serviceAccountAdmin",
       "roles/iam.serviceAccountUser",
+      "roles/compute.networkAdmin",
     ]
   }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,33 @@
  * limitations under the License.
  */
 
+locals {
+  per_module_services = {
+    valkey = [
+      "redis.googleapis.com",
+      "cloudkms.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    redis-cluster = [
+      "redis.googleapis.com",
+      "cloudkms.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    memcache = [
+      "memcache.googleapis.com",
+      "redis.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    root = [
+      "redis.googleapis.com",
+      "memcache.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+    ]
+  }
+}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 18.0"
@@ -27,17 +54,12 @@ module "project" {
   auto_create_network     = true
   deletion_policy         = "DELETE"
 
-  activate_apis = [
-    "cloudresourcemanager.googleapis.com",
-    "serviceusage.googleapis.com",
-    "redis.googleapis.com",
-    "memcache.googleapis.com",
+  activate_apis = concat([
     "serviceconsumermanagement.googleapis.com",
     "networkconnectivity.googleapis.com",
     "compute.googleapis.com",
     "memorystore.googleapis.com",
-    "cloudkms.googleapis.com"
-  ]
+  ], flatten(values(local.per_module_services)))
 }
 
 


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag --per-module-requirements to generate_docs cmd, to align with the per module configs.