### PR TITLE
Feat: Add "enable_api" module to Memorystore for Redis Instances examples

### DIFF
--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+module "enable_apis" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 18.0"
+
+  project_id                  = var.project_id
+  enable_apis                 = true
+  disable_services_on_destroy = false
+  disable_dependent_services  = false
+
+  activate_apis = [
+    "redis.googleapis.com",
+  ]
+}
+
 module "memstore" {
   source  = "terraform-google-modules/memorystore/google"
   version = "~> 14.0"
@@ -24,7 +38,7 @@ module "memstore" {
   region                  = "us-east1"
   location_id             = "us-east1-b"
   alternative_location_id = "us-east1-d"
-  enable_apis             = true
+  enable_apis             = false
   auth_enabled            = true
   transit_encryption_mode = "SERVER_AUTHENTICATION"
   authorized_network      = module.test-vpc-module.network_id


### PR DESCRIPTION
This PR introduces an "enable_api" module to the examples for Memorystore for Redis Instances.

Rationale: We currently have a dedicated enable_api module explicitly mentioned in our examples for Redis Cluster. The underlying reason for this is that most customers enable necessary APIs through their project factory setup. We believe this same rationale applies directly to Memorystore for Redis Instances. Customer behavior for API enablement is highly likely to be consistent across both Redis Cluster and standalone Redis Instances. 

Aim: By adding this enable_api module, we ensure that our examples better reflect common customer practices and are consistent with Redis Clusters. 
