### PR TITLE
chore: update Makefile to remove docker_test_integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,6 @@ docker_test_cleanup:
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/execute_with_credentials.sh cleanup_environment
 
-# Execute integration tests within the docker container
-.PHONY: docker_test_integration
-docker_test_integration:
-	docker run --rm -it \
-		-e SERVICE_ACCOUNT_JSON \
-		-v "$(CURDIR)":/workspace \
-		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/usr/local/bin/test_integration.sh
-
 # Execute lint tests within the docker container
 .PHONY: docker_test_lint
 docker_test_lint:


### PR DESCRIPTION
This PR removes the "docker_test_integration" target from the Makefile.

The docker_test_integration test currently requires a kitchen.yml file, which is not present. 
Furthermore, as told by abhiwa@, we're not planning to utilize this test in the near future, as our testing efforts will be focused on CFT tests instead.

Removing this unnecessary and non-working target improves the clarity of our Makefile.