### PR TITLE
fix(redis-cluster): ignore changes on secondary cluster's non modifiable variables post creation

### DIFF
--- a/modules/redis-cluster/main.tf
+++ b/modules/redis-cluster/main.tf
@@ -96,6 +96,20 @@ resource "google_redis_cluster" "redis_cluster" {
     }
   }
 
+  lifecycle {
+    ignore_changes = var.cluster_role == "SECONDARY" ? [
+      shard_count,
+      node_type,
+      transit_encryption_mode,
+      authorization_mode,
+      redis_configs,
+      kms_key,
+      psc_configs,
+      zone_distribution_config,
+      persistence_config,
+    ] : []
+  }
+
   depends_on = [
     google_network_connectivity_service_connection_policy.service_connection_policies,
     module.enable_apis,


### PR DESCRIPTION
Hi team!

I am using the memorystore module for redis cluster and found a little unwanted behavior. We have setup our current setup to use a shard_count variable that is then used by both our primary and secondary cluster, e.g.:

```
module "redis_cluster_primary" {
  source  = "terraform-google-modules/memorystore/google//modules/redis-cluster"
  version = "~> 14.0"

  name                    = var.name
  project_id              = var.project_id
  shard_count             = var.redis_architecture.shard_count
  region                  = var.primary_region
  network                 = var.network
  node_type               = var.redis_architecture.node_type
  enable_apis             = var.enable_apis
  replica_count           = var.redis_architecture.replica_count
  transit_encryption_mode = var.transit_encryption_mode
  authorization_mode      = var.authorization_mode
  redis_configs           = var.redis_configs

  persistence_config = var.persistence_config

  service_connection_policies = var.primary_service_connection_policies

  depends_on = [
    module.enable_apis,
  ]
}

module "redis_cluster_secondary" {
  source  = "terraform-google-modules/memorystore/google//modules/redis-cluster"
  version = "~> 14.0"

  count = var.secondary_region != null ? 1 : 0

  name                    = var.name
  project_id              = var.project_id
  shard_count             = var.redis_architecture.shard_count
  region                  = var.secondary_region
  ...
```

This works perfectly on creation, but I realized that on modification of the number of shards, to scale out for example, our terraform apply failed. This is because we received the following error:

```
│ Error: Error updating Cluster "projects/my-gcp-prj/locations/northamerica-northeast2/clusters/my-cluster": googleapi: Error 400: unsupported path in fieldMask: shard_count for secondary. Allowed values are maintenance_window, maintenance_policy, simulate_maintenance_event, deletion_protection_enabled, replica_count, maintenance_policy.weekly_maintenance_window, cross_cluster_replication_config, automated_backup_config, cluster_endpoints
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "field": "shard_count"
│       }
│     ]
│   }
│ ]
│ 
│   with [...].google_redis_cluster.redis_cluster,
│   on .terraform/.../main.tf line 17, in resource "google_redis_cluster" "redis_cluster":
│   17: resource "google_redis_cluster" "redis_cluster" {
│ 
```

The error is pretty self explanatory! Since the fields are required on creation, I think it would be pertinent to stop tracking changes on them after creation using ignore_changes.

Currently it makes my TF pipelines fail, and I thought about the fact that we could split the variables so that it doesn't change in lab, but I feel like that would lead us to have code that does not represent the real tf state, so I think using a variable for both and ignoring changes on secondary is a better solution.

Let me know how that sounds, or if you would have a better idea to fix this problem. Thanks!