### PR TITLE
Fix Valkey deprecate PSC auto connections

### DIFF
--- a/modules/redis-cluster/metadata.display.yaml
+++ b/modules/redis-cluster/metadata.display.yaml
@@ -35,6 +35,9 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value: AUTH_MODE_IAM_AUTH
+        cluster_role:
+          name: cluster_role
+          title: Cluster Role
         deletion_protection_enabled:
           name: deletion_protection_enabled
           title: Deletion Protection Enabled
@@ -75,6 +78,9 @@ spec:
           name: persistence_config
           title: Persistence Config
           level: 1
+        primary_cluster:
+          name: primary_cluster
+          title: Primary Cluster
         project:
           name: project
           title: Project
@@ -94,6 +100,9 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value: 1
+        secondary_clusters:
+          name: secondary_clusters
+          title: Secondary Clusters
         service_connection_policies:
           name: service_connection_policies
           title: Service Connection Policies

--- a/modules/redis-cluster/metadata.yaml
+++ b/modules/redis-cluster/metadata.yaml
@@ -151,6 +151,16 @@ spec:
                 append_fsync = optional(string)
               }))
             })
+      - name: cluster_role
+        description: "The role of the cluster in cross cluster replication. Possible values are: CLUSTER_ROLE_UNSPECIFIED, NONE, PRIMARY, SECONDARY"
+        varType: string
+      - name: primary_cluster
+        description: "primary cluster that is used as the replication source for this secondary cluster. This is allowed to be set only for clusters whose cluster role is of type SECONDARY. Format: projects/{project}/locations/{region}/clusters/{cluster-id}"
+        varType: string
+      - name: secondary_clusters
+        description: "List of secondary clusters that are replicating from this primary cluster. This is allowed to be set only for clusters whose cluster role is of type PRIMARY. Format: projects/{project}/locations/{region}/clusters/{cluster-id}"
+        varType: list(string)
+        defaultValue: []
       - name: labels
         description: The resource labels to represent user provided metadata.
         varType: map(string)

--- a/modules/valkey/main.tf
+++ b/modules/valkey/main.tf
@@ -22,7 +22,7 @@ resource "google_memorystore_instance" "valkey_cluster" {
   mode                = var.mode
   maintenance_version = var.maintenance_version
 
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network    = "projects/${coalesce(var.network_project, var.project_id)}/global/networks/${var.network}"
     project_id = var.project_id
   }

--- a/modules/valkey/outputs.tf
+++ b/modules/valkey/outputs.tf
@@ -21,7 +21,7 @@ output "id" {
 
 output "discovery_endpoints" {
   description = "(Deprecated) Endpoints created on each given network, for valkey clients to connect to the cluster. Currently only one endpoint is supported. Use endpoints instead"
-  value       = google_memorystore_instance.valkey_cluster.discovery_endpoints
+  value       = google_memorystore_instance.valkey_cluster.endpoints
 }
 
 output "psc_connections" {


### PR DESCRIPTION
### Summary
                                                                                                                                                                            
  - modules/valkey: Replace deprecated google_memorystore_instance attributes:
    - desired_psc_auto_connections → desired_auto_created_endpoints (provider now requires the new name for terraform import to work)                                                                                                                           
  - modules/redis-cluster: Add missing metadata entries for the three cross-cluster replication variables — cluster_role, primary_cluster, and secondary_clusters — in both metadata.yaml and metadata.display.yaml                                                                                                                                   
