### PR TITLE
fix(valkey): use network_project for desired_psc_auto_connections.project_id

### DIFF
--- a/modules/valkey/main.tf
+++ b/modules/valkey/main.tf
@@ -24,7 +24,7 @@ resource "google_memorystore_instance" "valkey_cluster" {
 
   desired_psc_auto_connections {
     network    = "projects/${coalesce(var.network_project, var.project_id)}/global/networks/${var.network}"
-    project_id = var.project_id
+    project_id = coalesce(var.network_project, var.project_id)
   }
 
   location                = var.location


### PR DESCRIPTION
## Summary

One-line fix. The `valkey` module already uses `coalesce(var.network_project, var.project_id)` for the `network` argument on the adjacent line and for the SCP resource below, but hardcodes `project_id = var.project_id` inside `desired_psc_auto_connections`. That breaks cross-project PSC because GCP tries to create the PSC endpoint in the instance's project rather than the network's project.

## The change

```diff
 desired_psc_auto_connections {
   network    = "projects/${coalesce(var.network_project, var.project_id)}/global/networks/${var.network}"
-  project_id = var.project_id
+  project_id = coalesce(var.network_project, var.project_id)
 }
```

For same-project setups (no `network_project` set), `coalesce` falls back to `var.project_id` — behaviour is unchanged for existing users.

## Reproduction

A `valkey` module call where `project_id != network_project` (e.g. data project for the instance, shared/host project for the network, no Shared VPC service-project attachment) apply-fails with:

```
Error 400: Failed to reserve IP from subnetwork projects/<network-project>/regions/<region>/subnetworks/<subnet>
in consumer endpoint project <instance-project> because the endpoint project is not a Shared VPC service project.
Cross-project references for this resource are not allowed.
```

After this fix, the endpoint is created in the network's project, IP allocation succeeds, and the instance reaches `READY`.

## Why no test in this PR

The existing `examples/valkey/` module uses a same-project setup, which doesn't exercise this code path either way. A genuinely-cross-project test needs two GCP projects plus careful IAM wiring (consumer project SA needs `networkconnectivity.consumerNetworkAdmin` + `compute.networkUser` on the network project) and so probably belongs in a new `examples/cross-project-valkey/` module. I can add that in a follow-up PR if the maintainers want — happy to mirror the style of the existing examples. Flagged as out of scope here to keep the fix commit minimal.

## Relationship to #314

This PR is not the `desired_psc_auto_connections` → `desired_auto_created_endpoints` rename that #314 is about. A proper rename would need to update field names across the resource and module outputs too; this PR keeps scope tight to the cross-project bug. Once #314 is addressed, the same `coalesce` pattern should apply to the renamed attribute.

Fixes #361