### PR TITLE
feat: add server_ca_pool and server_ca_mode in valkey sub-module

### DIFF
--- a/examples/redis-cluster/iam.tf
+++ b/examples/redis-cluster/iam.tf
@@ -25,7 +25,13 @@ resource "google_project_service_identity" "network_connectivity_sa" {
 }
 
 resource "google_project_iam_member" "network_connectivity_sa" {
-  project = var.project_id
-  role    = "roles/networkconnectivity.serviceAgent"
-  member  = "serviceAccount:${google_project_service_identity.network_connectivity_sa.email}"
+  project    = var.project_id
+  role       = "roles/networkconnectivity.serviceAgent"
+  member     = "serviceAccount:${google_project_service_identity.network_connectivity_sa.email}"
+  depends_on = [time_sleep.wait_for_network_connectivity_sa_ready_state]
+}
+
+resource "time_sleep" "wait_for_network_connectivity_sa_ready_state" {
+  create_duration = "30s"
+  depends_on      = [google_project_service_identity.network_connectivity_sa]
 }

--- a/examples/redis-cluster/kms.tf
+++ b/examples/redis-cluster/kms.tf
@@ -34,12 +34,12 @@ resource "random_string" "key_suffix" {
 
 resource "google_kms_key_ring" "keyring_region_central" {
   project  = var.project_id
-  name     = "keyring-us-central1-${random_string.key_suffix.result}"
-  location = "us-central1"
+  name     = "keyring-us-south1-${random_string.key_suffix.result}"
+  location = "us-south1"
 }
 
 resource "google_kms_crypto_key" "key_region_central" {
-  name     = "key-us-central1-${random_string.key_suffix.result}"
+  name     = "key-us-south1-${random_string.key_suffix.result}"
   key_ring = google_kms_key_ring.keyring_region_central.id
 }
 

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -39,7 +39,7 @@ module "redis_cluster_central" {
 
   name                        = "test-redis-cluster-central"
   project_id                  = var.project_id
-  region                      = "us-central1"
+  region                      = "us-south1"
   network                     = ["projects/${var.project_id}/global/networks/${local.network_name}"]
   node_type                   = "REDIS_STANDARD_SMALL"
   deletion_protection_enabled = false
@@ -51,8 +51,8 @@ module "redis_cluster_central" {
       network_name    = local.network_name
       network_project = var.project_id
       subnet_names = [
-        "subnet-us-central1-100",
-        "subnet-us-central1-101",
+        "subnet-us-south1-200",
+        "subnet-us-south1-201",
       ]
     }
   }

--- a/examples/redis-cluster/network.tf
+++ b/examples/redis-cluster/network.tf
@@ -27,14 +27,14 @@ module "test_vpc" {
 
   subnets = [
     {
-      subnet_name   = "subnet-us-central1-100"
-      subnet_ip     = "10.10.100.0/24"
-      subnet_region = "us-central1"
+      subnet_name   = "subnet-us-south1-200"
+      subnet_ip     = "10.10.200.0/24"
+      subnet_region = "us-south1"
     },
     {
-      subnet_name   = "subnet-us-central1-101"
-      subnet_ip     = "10.10.101.0/24"
-      subnet_region = "us-central1"
+      subnet_name   = "subnet-us-south1-201"
+      subnet_ip     = "10.10.201.0/24"
+      subnet_region = "us-south1"
     },
     {
       subnet_name   = "subnet-us-east1-102"

--- a/examples/valkey/iam.tf
+++ b/examples/valkey/iam.tf
@@ -25,7 +25,13 @@ resource "google_project_service_identity" "network_connectivity_sa" {
 }
 
 resource "google_project_iam_member" "network_connectivity_sa" {
-  project = var.project_id
-  role    = "roles/networkconnectivity.serviceAgent"
-  member  = "serviceAccount:${google_project_service_identity.network_connectivity_sa.email}"
+  project    = var.project_id
+  role       = "roles/networkconnectivity.serviceAgent"
+  member     = "serviceAccount:${google_project_service_identity.network_connectivity_sa.email}"
+  depends_on = [time_sleep.wait_for_network_connectivity_sa_ready_state]
+}
+
+resource "time_sleep" "wait_for_network_connectivity_sa_ready_state" {
+  create_duration = "30s"
+  depends_on      = [google_project_service_identity.network_connectivity_sa]
 }

--- a/examples/valkey/kms.tf
+++ b/examples/valkey/kms.tf
@@ -32,40 +32,19 @@ resource "random_string" "key_suffix" {
   upper   = false
 }
 
-resource "google_kms_key_ring" "keyring_region_central" {
+resource "google_kms_key_ring" "keyring_region_west" {
   project  = var.project_id
-  name     = "keyring-us-central1-${random_string.key_suffix.result}"
-  location = "us-central1"
+  name     = "keyring-us-west1-${random_string.key_suffix.result}"
+  location = "us-west1"
 }
 
-resource "google_kms_crypto_key" "key_region_central" {
-  name     = "key-us-central1-${random_string.key_suffix.result}"
-  key_ring = google_kms_key_ring.keyring_region_central.id
+resource "google_kms_crypto_key" "key_region_west" {
+  name     = "key-us-west1-${random_string.key_suffix.result}"
+  key_ring = google_kms_key_ring.keyring_region_west.id
 }
 
-
-resource "google_kms_crypto_key_iam_member" "memorystore_sa_iam" {
-  crypto_key_id = google_kms_crypto_key.key_region_central.id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${google_project_service_identity.memorystore_sa.email}"
-
-  depends_on = [time_sleep.wait_for_memorystore_sa_ready_state]
-}
-
-resource "google_kms_key_ring" "keyring_region_east" {
-  project  = var.project_id
-  name     = "keyring-us-east1-${random_string.key_suffix.result}"
-  location = "us-east1"
-}
-
-resource "google_kms_crypto_key" "key_region_east" {
-  name     = "key-us-east1-${random_string.key_suffix.result}"
-  key_ring = google_kms_key_ring.keyring_region_east.id
-}
-
-
-resource "google_kms_crypto_key_iam_member" "memorystore_sa_iam_east" {
-  crypto_key_id = google_kms_crypto_key.key_region_east.id
+resource "google_kms_crypto_key_iam_member" "memorystore_sa_iam_west" {
+  crypto_key_id = google_kms_crypto_key.key_region_west.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_project_service_identity.memorystore_sa.email}"
 

--- a/examples/valkey/main.tf
+++ b/examples/valkey/main.tf
@@ -29,18 +29,19 @@ module "enable_apis" {
     "serviceconsumermanagement.googleapis.com",
     "networkconnectivity.googleapis.com",
     "compute.googleapis.com",
+    "privateca.googleapis.com",
   ]
 }
 
+module "valkey_cluster_south1" {
+  source  = "../../modules/valkey"
 
-module "valkey_cluster_central1" {
-  source  = "terraform-google-modules/memorystore/google//modules/valkey"
-  version = "~> 16.0"
+  instance_id             = "test-valkey-cluster-south1"
+  project_id              = var.project_id
+  location                = "us-south1"
+  node_type               = "STANDARD_SMALL"
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
 
-  instance_id                 = "test-valkey-cluster-central1"
-  project_id                  = var.project_id
-  location                    = "us-central1"
-  node_type                   = "HIGHMEM_MEDIUM"
   deletion_protection_enabled = false
   engine_version              = "VALKEY_8_0"
 
@@ -49,8 +50,8 @@ module "valkey_cluster_central1" {
   service_connection_policies = {
     test-net-valkey-cluster-scp = {
       subnet_names = [
-        "valkey-subnet-100",
-        "valkey-subnet-101",
+        "valkey-subnet-200",
+        "valkey-subnet-201",
       ]
     }
   }
@@ -87,15 +88,17 @@ module "valkey_cluster_central1" {
 }
 
 module "valkey_cluster_east1" {
-  source  = "terraform-google-modules/memorystore/google//modules/valkey"
-  version = "~> 16.0"
+  source  = "../../modules/valkey"
 
-  instance_id                 = "test-valkey-cluster-east1"
-  project_id                  = var.project_id
-  location                    = "us-east1"
-  node_type                   = "HIGHMEM_MEDIUM"
+  instance_id             = "test-valkey-cluster-east1"
+  project_id              = var.project_id
+  location                = "us-east1"
+  node_type               = "STANDARD_SMALL"
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
+
   deletion_protection_enabled = false
   engine_version              = "VALKEY_8_0"
+  server_ca_mode              = "GOOGLE_MANAGED_SHARED_CA"
 
   network = local.network_name
 
@@ -107,7 +110,7 @@ module "valkey_cluster_east1" {
     }
   }
   instance_role    = "SECONDARY"
-  primary_instance = module.valkey_cluster_central1.id
+  primary_instance = module.valkey_cluster_south1.id
 
   persistence_config = {
     mode = "RDB"
@@ -137,6 +140,66 @@ module "valkey_cluster_east1" {
     module.test_vpc,
     module.enable_apis,
     google_project_iam_member.network_connectivity_sa,
-    module.valkey_cluster_central1,
+    module.valkey_cluster_south1,
+  ]
+}
+
+module "valkey_cluster_west1" {
+  source  = "../../modules/valkey"
+
+  instance_id             = "test-valkey-cluster-west1"
+  project_id              = var.project_id
+  location                = "us-west1"
+  node_type               = "STANDARD_SMALL"
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
+
+  deletion_protection_enabled = false
+  engine_version              = "VALKEY_8_0"
+  server_ca_mode              = "CUSTOMER_MANAGED_CAS_CA"
+
+  server_ca_pool = google_privateca_ca_pool.ca_pool_region_west.id
+  kms_key        = google_kms_crypto_key.key_region_west.id
+
+  network = local.network_name
+
+  service_connection_policies = {
+    test-net-valkey-cluster-scp = {
+      subnet_names = [
+        "valkey-subnet-103",
+      ]
+    }
+  }
+
+  persistence_config = {
+    mode = "RDB"
+    rdb_config = {
+      rdb_snapshot_period     = "ONE_HOUR"
+      rdb_snapshot_start_time = "2024-10-02T15:01:23Z"
+    }
+  }
+
+  engine_configs = {
+    maxmemory-policy = "volatile-ttl"
+  }
+
+  weekly_maintenance_window = [
+    {
+      day_of_week     = "MONDAY"
+      start_time_hour = "23"
+    }
+  ]
+
+  automated_backup_config = {
+    start_time = "20"
+    retention  = "86400s"
+  }
+
+  depends_on = [
+    module.test_vpc,
+    module.enable_apis,
+    google_project_iam_member.network_connectivity_sa,
+    google_privateca_certificate_authority.ca_west_authority,
+    google_kms_crypto_key_iam_member.memorystore_sa_iam_west,
+    time_sleep.wait_for_ca_pool_iam_propagation,
   ]
 }

--- a/examples/valkey/network.tf
+++ b/examples/valkey/network.tf
@@ -27,19 +27,24 @@ module "test_vpc" {
 
   subnets = [
     {
-      subnet_name   = "valkey-subnet-100"
-      subnet_ip     = "10.10.100.0/24"
-      subnet_region = "us-central1"
+      subnet_name   = "valkey-subnet-200"
+      subnet_ip     = "10.10.200.0/24"
+      subnet_region = "us-south1"
     },
     {
-      subnet_name   = "valkey-subnet-101"
-      subnet_ip     = "10.10.101.0/24"
-      subnet_region = "us-central1"
+      subnet_name   = "valkey-subnet-201"
+      subnet_ip     = "10.10.201.0/24"
+      subnet_region = "us-south1"
     },
     {
       subnet_name   = "valkey-subnet-102"
       subnet_ip     = "10.10.102.0/24"
       subnet_region = "us-east1"
+    },
+    {
+      subnet_name   = "valkey-subnet-103"
+      subnet_ip     = "10.10.103.0/24"
+      subnet_region = "us-west1"
     },
   ]
 }

--- a/examples/valkey/outputs.tf
+++ b/examples/valkey/outputs.tf
@@ -16,50 +16,50 @@
 
 output "cluster_id" {
   description = "The valkey cluster instance ID"
-  value       = module.valkey_cluster_central1.id
+  value       = module.valkey_cluster_south1.id
 }
 
 output "size_gb" {
   description = "The valkey cluster size"
-  value       = module.valkey_cluster_central1.valkey_cluster.node_config[0].size_gb
+  value       = module.valkey_cluster_south1.valkey_cluster.node_config[0].size_gb
 }
 
 output "cluster_region" {
   description = "The valkey cluster region"
-  value       = module.valkey_cluster_central1.valkey_cluster.location
+  value       = module.valkey_cluster_south1.valkey_cluster.location
 }
 
 output "replica_count" {
   description = "The valkey cluster replica count"
-  value       = module.valkey_cluster_central1.valkey_cluster.replica_count
+  value       = module.valkey_cluster_south1.valkey_cluster.replica_count
 }
 
 output "transit_encryption_mode" {
   description = "The valkey cluster transit encryption mode"
-  value       = module.valkey_cluster_central1.valkey_cluster.transit_encryption_mode
+  value       = module.valkey_cluster_south1.valkey_cluster.transit_encryption_mode
 }
 
 output "cluster_name" {
   description = "The valkey cluster name"
-  value       = module.valkey_cluster_central1.valkey_cluster.instance_id
+  value       = module.valkey_cluster_south1.valkey_cluster.instance_id
 }
 
 output "shard_count" {
   description = "The valkey cluster shard count"
-  value       = module.valkey_cluster_central1.valkey_cluster.shard_count
+  value       = module.valkey_cluster_south1.valkey_cluster.shard_count
 }
 
 output "authorization_mode" {
   description = "The valkey cluster authorization mode"
-  value       = module.valkey_cluster_central1.valkey_cluster.authorization_mode
+  value       = module.valkey_cluster_south1.valkey_cluster.authorization_mode
 }
 
 output "node_type" {
   description = "The valkey cluster node type"
-  value       = module.valkey_cluster_central1.valkey_cluster.node_type
+  value       = module.valkey_cluster_south1.valkey_cluster.node_type
 }
 
 output "cluster" {
   description = "The valkey cluster created"
-  value       = module.valkey_cluster_central1
+  value       = module.valkey_cluster_south1
 }

--- a/examples/valkey/server_ca.tf
+++ b/examples/valkey/server_ca.tf
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_privateca_ca_pool" "ca_pool_region_west" {
+  provider = google-beta
+
+  project  = var.project_id
+  name     = "ca-pool-us-west1-${random_string.key_suffix.result}"
+  location = "us-west1"
+  tier     = "ENTERPRISE"
+
+  depends_on = [module.enable_apis]
+}
+
+resource "google_privateca_ca_pool_iam_member" "memorystore_sa_ca_iam" {
+  provider = google-beta
+
+  ca_pool = google_privateca_ca_pool.ca_pool_region_west.id
+  role    = "roles/privateca.certificateRequester"
+  member  = "serviceAccount:${google_project_service_identity.memorystore_sa.email}"
+
+  depends_on = [time_sleep.wait_for_memorystore_sa_ready_state]
+}
+
+resource "google_privateca_certificate_authority" "ca_west_authority" {
+  provider = google-beta
+  project  = var.project_id
+
+  pool                     = google_privateca_ca_pool.ca_pool_region_west.name
+  certificate_authority_id = "ca-auth-us-west1-${random_string.key_suffix.result}"
+  location                 = "us-west1"
+
+  config {
+    subject_config {
+      subject {
+        organization = "Test Org"
+        common_name  = "test-ca"
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          cert_sign = true
+          crl_sign  = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+
+  deletion_protection                    = false
+  ignore_active_certificates_on_deletion = true
+  skip_grace_period                      = true
+
+  depends_on = [module.enable_apis]
+}
+
+resource "time_sleep" "wait_for_ca_pool_iam_propagation" {
+  create_duration = "120s"
+  depends_on      = [google_privateca_ca_pool_iam_member.memorystore_sa_ca_iam]
+}

--- a/modules/valkey/README.md
+++ b/modules/valkey/README.md
@@ -64,6 +64,8 @@ module "valkey_cluster" {
 | project\_id | The ID of the project in which the resource belongs to. | `string` | n/a | yes |
 | replica\_count | Number of replica nodes per shard. If omitted the default is 0 replicas | `number` | `0` | no |
 | secondary\_instance | List of secondary instances that are replicating from this primary instance. This is allowed to be set only for instances whose instance role is of type PRIMARY. Format: projects/{project}/locations/{region}/instances/{instance-id} | `list(string)` | `[]` | no |
+| server\_ca\_mode | The Server CA mode of the instance. Possible values: GOOGLE\_MANAGED\_PER\_INSTANCE\_CA, GOOGLE\_MANAGED\_SHARED\_CA, CUSTOMER\_MANAGED\_CAS\_CA, SERVER\_CA\_MODE\_UNSPECIFIED | `string` | `null` | no |
+| server\_ca\_pool | The customer-managed CA pool resource name. Format: projects/{project}/locations/{location}/caPools/{caPoolId} | `string` | `null` | no |
 | service\_connection\_policies | The Service Connection Policies to create. Required to create service connection policy. Not needed if service connection policy already exist | <pre>map(object({<br>    subnet_names = list(string)<br>    description  = optional(string)<br>    limit        = optional(number)<br>    labels       = optional(map(string), {})<br>  }))</pre> | `{}` | no |
 | shard\_count | Number of shards for the instance | `number` | `3` | no |
 | transit\_encryption\_mode | Immutable. In-transit encryption mode of the instance. Possible values: TRANSIT\_ENCRYPTION\_DISABLED SERVER\_AUTHENTICATION | `string` | `"TRANSIT_ENCRYPTION_DISABLED"` | no |

--- a/modules/valkey/main.tf
+++ b/modules/valkey/main.tf
@@ -63,8 +63,10 @@ resource "google_memorystore_instance" "valkey_cluster" {
       }
     }
   }
-  kms_key = var.kms_key
-  labels  = var.labels
+  kms_key        = var.kms_key
+  server_ca_mode = var.server_ca_mode
+  server_ca_pool = var.server_ca_pool
+  labels         = var.labels
 
   dynamic "managed_backup_source" {
     for_each = var.managed_backup_source != null ? ["managed_backup_source"] : []

--- a/modules/valkey/metadata.display.yaml
+++ b/modules/valkey/metadata.display.yaml
@@ -97,6 +97,26 @@ spec:
         secondary_instance:
           name: secondary_instance
           title: Secondary Instance
+        server_ca_mode:
+          name: server_ca_mode
+          title: Server Ca Mode
+          enumValueLabels:
+            - label: Google Managed Per Instance CA
+              value: GOOGLE_MANAGED_PER_INSTANCE_CA
+            - label: Google Managed Shared CA
+              value: GOOGLE_MANAGED_SHARED_CA
+            - label: Customer Managed CAS CA
+              value: CUSTOMER_MANAGED_CAS_CA
+            - label: TLS Disabled
+              value: SERVER_CA_MODE_UNSPECIFIED
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: SERVER_CA_MODE_UNSPECIFIED
+        server_ca_pool:
+          name: server_ca_pool
+          title: Server Ca Pool
+          regexValidation: "^projects/((?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)))/locations/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))/caPools/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
+          validation: Invalid format. Expected a valid Google Cloud CA Pool in the form of projects/{project_id}/locations/{location}/caPools/{ca_pool_id}.
         service_connection_policies:
           name: service_connection_policies
           title: Service Connection Policies

--- a/modules/valkey/metadata.yaml
+++ b/modules/valkey/metadata.yaml
@@ -184,6 +184,12 @@ spec:
       - name: kms_key
         description: The KMS key used to encrypt the at-rest data of the cluster
         varType: string
+      - name: server_ca_mode
+        description: "The Server CA mode of the instance. Possible values: GOOGLE_MANAGED_PER_INSTANCE_CA, GOOGLE_MANAGED_SHARED_CA, CUSTOMER_MANAGED_CAS_CA, SERVER_CA_MODE_UNSPECIFIED"
+        varType: string
+      - name: server_ca_pool
+        description: "The customer-managed CA pool resource name. Format: projects/{project}/locations/{location}/caPools/{caPoolId}"
+        varType: string
     outputs:
       - name: available_maintenance_versions
         description: This field is used to determine the available maintenance versions for the self service update
@@ -213,4 +219,4 @@ spec:
       - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 6.30, < 7"
+        version: ">= 7.24, < 8"

--- a/modules/valkey/variables.tf
+++ b/modules/valkey/variables.tf
@@ -214,3 +214,21 @@ variable "kms_key" {
   type        = string
   default     = null
 }
+
+variable "server_ca_mode" {
+  description = "The Server CA mode of the instance. Possible values: GOOGLE_MANAGED_PER_INSTANCE_CA, GOOGLE_MANAGED_SHARED_CA, CUSTOMER_MANAGED_CAS_CA, SERVER_CA_MODE_UNSPECIFIED"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.server_ca_mode == null ? true : contains(["GOOGLE_MANAGED_PER_INSTANCE_CA", "GOOGLE_MANAGED_SHARED_CA", "CUSTOMER_MANAGED_CAS_CA", "SERVER_CA_MODE_UNSPECIFIED"], var.server_ca_mode)
+    error_message = "Allowed values for server_ca_mode are \"GOOGLE_MANAGED_PER_INSTANCE_CA\", \"GOOGLE_MANAGED_SHARED_CA\", \"CUSTOMER_MANAGED_CAS_CA\", or null."
+  }
+}
+
+variable "server_ca_pool" {
+  description = "The customer-managed CA pool resource name. Format: projects/{project}/locations/{location}/caPools/{caPoolId}"
+  type        = string
+  default     = null
+}
+

--- a/modules/valkey/versions.tf
+++ b/modules/valkey/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.13, < 8"
+      version = ">= 7.24, < 8"
     }
   }
 

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -22,6 +22,7 @@ locals {
       "roles/iam.serviceAccountUser",
       "roles/logging.logWriter",
       "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+      "roles/privateca.admin",
     ]
     redis-cluster = [
       "roles/redis.admin",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -19,6 +19,7 @@ locals {
     valkey = [
       "redis.googleapis.com",
       "cloudkms.googleapis.com",
+      "privateca.googleapis.com",
       "serviceusage.googleapis.com",
     ]
     redis-cluster = [


### PR DESCRIPTION
1 / 2 Stacked PRs
- add server_ca_pool and server_ca_mode in valkey sub-module
- fix KMS not being used in example
- point to local version for examples till 16.2.0 is not published
- Change region to us-south1 from us-central1 due to stockouts
- increment minimum provider version to 7.24 as server_ca_mode and server_ca_pool were added in [7.24](https://github.com/hashicorp/terraform-provider-google/releases?page=3#release-v7.24.0)