### PR TITLE
feat: update defaults for valkey and add UI levels

### DIFF
--- a/examples/valkey/main.tf
+++ b/examples/valkey/main.tf
@@ -34,7 +34,7 @@ module "enable_apis" {
 }
 
 module "valkey_cluster_south1" {
-  source  = "../../modules/valkey"
+  source = "../../modules/valkey"
 
   instance_id             = "test-valkey-cluster-south1"
   project_id              = var.project_id
@@ -88,7 +88,7 @@ module "valkey_cluster_south1" {
 }
 
 module "valkey_cluster_east1" {
-  source  = "../../modules/valkey"
+  source = "../../modules/valkey"
 
   instance_id             = "test-valkey-cluster-east1"
   project_id              = var.project_id
@@ -145,7 +145,7 @@ module "valkey_cluster_east1" {
 }
 
 module "valkey_cluster_west1" {
-  source  = "../../modules/valkey"
+  source = "../../modules/valkey"
 
   instance_id             = "test-valkey-cluster-west1"
   project_id              = var.project_id

--- a/modules/valkey/README.md
+++ b/modules/valkey/README.md
@@ -44,7 +44,7 @@ module "valkey_cluster" {
 | authorization\_mode | The Immutable. Authorization mode of the instance. Possible values: AUTH\_DISABLED IAM\_AUTH | `string` | `"AUTH_DISABLED"` | no |
 | automated\_backup\_config | The automated backup config for a instance | <pre>object({<br>    start_time = string<br>    retention  = string<br>  })</pre> | `null` | no |
 | deletion\_protection\_enabled | If set to true deletion of the instance will fail | `bool` | `true` | no |
-| enable\_apis | Flag for enabling memcache.googleapis.com in your project | `bool` | `false` | no |
+| enable\_apis | Flag for enabling memorystore.googleapis.com in your project | `bool` | `false` | no |
 | engine\_configs | User-provided engine configurations for the instance | <pre>object({<br>    maxmemory               = optional(string)<br>    maxmemory-clients       = optional(string)<br>    maxmemory-policy        = optional(string)<br>    notify-keyspace-events  = optional(string)<br>    slowlog-log-slower-than = optional(number)<br>    maxclients              = optional(number)<br>  })</pre> | `null` | no |
 | engine\_version | Engine version of the instance | `string` | `"VALKEY_8_0"` | no |
 | gcs\_source | GCS source for the instance. Format gs://bucket1/object1, gs://bucket2/folder2/object2 | `string` | `null` | no |
@@ -58,7 +58,7 @@ module "valkey_cluster" {
 | mode | cluster or cluster-disabled. Possible values: CLUSTER, CLUSTER\_DISABLED | `string` | `null` | no |
 | network | Name of the consumer network where the network address of the discovery endpoint will be reserved | `string` | n/a | yes |
 | network\_project | project ID of the consumer network where the network address of the discovery endpoint will be reserved. Required for Shared VPC host | `string` | `null` | no |
-| node\_type | The nodeType for the valkey cluster. Possible values are: SHARED\_CORE\_NANO, HIGHMEM\_MEDIUM, HIGHMEM\_XLARGE, STANDARD\_SMALL | `string` | `null` | no |
+| node\_type | The nodeType for the valkey cluster. Possible values are: SHARED\_CORE\_NANO, HIGHMEM\_MEDIUM, HIGHMEM\_XLARGE, STANDARD\_SMALL, CUSTOM\_MICRO, CUSTOM\_MINI, HIGHCPU\_MEDIUM, STANDARD\_LARGE, HIGHMEM\_2XLARGE, CUSTOM\_PICO | `string` | `null` | no |
 | persistence\_config | User-provided persistence configurations for the instance | <pre>object({<br>    mode = optional(string)<br>    rdb_config = optional(object({<br>      rdb_snapshot_period     = optional(string)<br>      rdb_snapshot_start_time = optional(string)<br>    }), null)<br>    aof_config = optional(object({<br>      append_fsync = string<br>    }), null)<br>  })</pre> | `{}` | no |
 | primary\_instance | primary instance that is used as the replication source for this secondary instance. This is allowed to be set only for instances whose instance role is of type SECONDARY. Format: projects/{project}/locations/{region}/instances/{instance-id} | `string` | `null` | no |
 | project\_id | The ID of the project in which the resource belongs to. | `string` | n/a | yes |
@@ -77,9 +77,11 @@ module "valkey_cluster" {
 
 | Name | Description |
 |------|-------------|
+| apphub\_service\_uri | Service URI in CAIS style to be used by Apphub. |
 | available\_maintenance\_versions | This field is used to determine the available maintenance versions for the self service update |
 | discovery\_endpoints | (Deprecated) Endpoints created on each given network, for valkey clients to connect to the cluster. Currently only one endpoint is supported. Use endpoints instead |
 | endpoints | Endpoints for the instance |
+| env\_vars | Environment variables for Valkey instance connection, including address and port. |
 | id | The valkey cluster instance ID |
 | psc\_auto\_connection | Detailed information of a PSC connection that is created through service connectivity automation |
 | psc\_connections | (Deprecated) PSC connections for discovery of the cluster topology and accessing the cluster. Use psc\_auto\_connection instead |

--- a/modules/valkey/metadata.display.yaml
+++ b/modules/valkey/metadata.display.yaml
@@ -31,33 +31,59 @@ spec:
         authorization_mode:
           name: authorization_mode
           title: Authorization Mode
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: IAM_AUTH
         automated_backup_config:
           name: automated_backup_config
           title: Automated Backup Config
         deletion_protection_enabled:
           name: deletion_protection_enabled
           title: Deletion Protection Enabled
+          level: 1
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: true
         enable_apis:
           name: enable_apis
           title: Enable Apis
+          level: 1
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: true
         engine_configs:
           name: engine_configs
           title: Engine Configs
+          level: 1
         engine_version:
           name: engine_version
           title: Engine Version
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: VALKEY_9_0
         gcs_source:
           name: gcs_source
           title: Gcs Source
         instance_id:
           name: instance_id
           title: Instance Id
+          regexValidation: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
+          validation: Instance ID must use only lowercase letters, numbers, and hyphens. It must also start with a letter and be unique in its region.
         instance_role:
           name: instance_role
           title: Instance Role
+          enumValueLabels:
+            - label: NONE
+              value: NONE
+            - label: PRIMARY
+              value: PRIMARY
+            - label: SECONDARY
+              value: SECONDARY
+          level: 1
         kms_key:
           name: kms_key
           title: Kms Key
+          level: 1
         labels:
           name: labels
           title: Labels
@@ -73,41 +99,57 @@ spec:
         mode:
           name: mode
           title: Mode
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: CLUSTER
         network:
           name: network
           title: Network
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: default
         network_project:
           name: network_project
           title: Network Project
         node_type:
           name: node_type
           title: Node Type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: HIGHMEM_MEDIUM
         persistence_config:
           name: persistence_config
           title: Persistence Config
+          level: 1
         primary_instance:
           name: primary_instance
           title: Primary Instance
+          level: 1
         project_id:
           name: project_id
           title: Project Id
         replica_count:
           name: replica_count
           title: Replica Count
+          level: 1
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: 1
         secondary_instance:
           name: secondary_instance
           title: Secondary Instance
+          level: 1
         server_ca_mode:
           name: server_ca_mode
           title: Server Ca Mode
           enumValueLabels:
-            - label: Google Managed Per Instance CA
+            - label: GOOGLE_MANAGED_PER_INSTANCE_CA
               value: GOOGLE_MANAGED_PER_INSTANCE_CA
-            - label: Google Managed Shared CA
+            - label: GOOGLE_MANAGED_SHARED_CA
               value: GOOGLE_MANAGED_SHARED_CA
-            - label: Customer Managed CAS CA
+            - label: CUSTOMER_MANAGED_CAS_CA
               value: CUSTOMER_MANAGED_CAS_CA
-            - label: TLS Disabled
+            - label: SERVER_CA_MODE_UNSPECIFIED
               value: SERVER_CA_MODE_UNSPECIFIED
           altDefaults:
             - type: ALTERNATE_TYPE_DC
@@ -115,23 +157,40 @@ spec:
         server_ca_pool:
           name: server_ca_pool
           title: Server Ca Pool
-          regexValidation: "^projects/((?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)))/locations/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))/caPools/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
+          regexValidation: ^(?:(?:http(?:s)?://.+/)|(?://[a-zA-Z0-9-.]+/))?projects/((?:(?:[-a-z0-9]{1,63}\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)))/locations/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))/caPools/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$
           validation: Invalid format. Expected a valid Google Cloud CA Pool in the form of projects/{project_id}/locations/{location}/caPools/{ca_pool_id}.
         service_connection_policies:
           name: service_connection_policies
           title: Service Connection Policies
+          level: 1
         shard_count:
           name: shard_count
           title: Shard Count
+          regexValidation: ^(?:[1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|250)$
+          validation: Must be an integer value between 1 and 250.
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: 10
         transit_encryption_mode:
           name: transit_encryption_mode
           title: Transit Encryption Mode
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: TRANSIT_ENCRYPTION_DISABLED
         weekly_maintenance_window:
           name: weekly_maintenance_window
           title: Weekly Maintenance Window
         zone_distribution_config_mode:
           name: zone_distribution_config_mode
           title: Zone Distribution Config Mode
+          level: 1
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: MULTI_ZONE
         zone_distribution_config_zone:
           name: zone_distribution_config_zone
           title: Zone Distribution Config Zone
+    runtime:
+      outputs:
+        env_vars:
+          visibility: VISIBILITY_ROOT

--- a/modules/valkey/metadata.yaml
+++ b/modules/valkey/metadata.yaml
@@ -82,7 +82,7 @@ spec:
         varType: string
         defaultValue: TRANSIT_ENCRYPTION_DISABLED
       - name: node_type
-        description: "The nodeType for the valkey cluster. Possible values are: SHARED_CORE_NANO, HIGHMEM_MEDIUM, HIGHMEM_XLARGE, STANDARD_SMALL"
+        description: "The nodeType for the valkey cluster. Possible values are: SHARED_CORE_NANO, HIGHMEM_MEDIUM, HIGHMEM_XLARGE, STANDARD_SMALL, CUSTOM_MICRO, CUSTOM_MINI, HIGHCPU_MEDIUM, STANDARD_LARGE, HIGHMEM_2XLARGE, CUSTOM_PICO"
         varType: string
       - name: deletion_protection_enabled
         description: If set to true deletion of the instance will fail
@@ -100,7 +100,7 @@ spec:
         varType: string
         defaultValue: VALKEY_8_0
       - name: enable_apis
-        description: Flag for enabling memcache.googleapis.com in your project
+        description: Flag for enabling memorystore.googleapis.com in your project
         varType: bool
         defaultValue: false
       - name: network
@@ -191,12 +191,25 @@ spec:
         description: "The customer-managed CA pool resource name. Format: projects/{project}/locations/{location}/caPools/{caPoolId}"
         varType: string
     outputs:
+      - name: apphub_service_uri
+        description: Service URI in CAIS style to be used by Apphub.
+        type:
+          - object
+          - location: string
+            service_id: string
+            service_uri: string
       - name: available_maintenance_versions
         description: This field is used to determine the available maintenance versions for the self service update
       - name: discovery_endpoints
         description: (Deprecated) Endpoints created on each given network, for valkey clients to connect to the cluster. Currently only one endpoint is supported. Use endpoints instead
       - name: endpoints
         description: Endpoints for the instance
+      - name: env_vars
+        description: Environment variables for Valkey instance connection, including address and port.
+        type:
+          - object
+          - VALKEY_HOST: string
+            VALKEY_PORT: string
       - name: id
         description: The valkey cluster instance ID
       - name: psc_auto_connection

--- a/modules/valkey/outputs.tf
+++ b/modules/valkey/outputs.tf
@@ -44,6 +44,23 @@ output "psc_auto_connection" {
   value       = google_memorystore_instance.valkey_cluster.endpoints[0].connections[0]
 }
 
+output "env_vars" {
+  description = "Environment variables for Valkey instance connection, including address and port."
+  value = {
+    "VALKEY_HOST" = google_memorystore_instance.valkey_cluster.endpoints[0].connections[0].psc_auto_connection[0].ip_address
+    "VALKEY_PORT" = tostring(google_memorystore_instance.valkey_cluster.endpoints[0].connections[0].psc_auto_connection[0].port)
+  }
+}
+
+output "apphub_service_uri" {
+  value = {
+    service_uri = "//memorystore.googleapis.com/${google_memorystore_instance.valkey_cluster.id}"
+    service_id  = substr("${var.instance_id}-${md5("MVC-${var.location}-${var.project_id}")}", 0, 63)
+    location    = var.location
+  }
+  description = "Service URI in CAIS style to be used by Apphub."
+}
+
 output "available_maintenance_versions" {
   description = "This field is used to determine the available maintenance versions for the self service update"
   value       = google_memorystore_instance.valkey_cluster.available_maintenance_versions

--- a/modules/valkey/variables.tf
+++ b/modules/valkey/variables.tf
@@ -66,7 +66,7 @@ variable "transit_encryption_mode" {
 }
 
 variable "node_type" {
-  description = "The nodeType for the valkey cluster. Possible values are: SHARED_CORE_NANO, HIGHMEM_MEDIUM, HIGHMEM_XLARGE, STANDARD_SMALL"
+  description = "The nodeType for the valkey cluster. Possible values are: SHARED_CORE_NANO, HIGHMEM_MEDIUM, HIGHMEM_XLARGE, STANDARD_SMALL, CUSTOM_MICRO, CUSTOM_MINI, HIGHCPU_MEDIUM, STANDARD_LARGE, HIGHMEM_2XLARGE, CUSTOM_PICO"
   type        = string
   default     = null
 }
@@ -96,7 +96,7 @@ variable "engine_version" {
 }
 
 variable "enable_apis" {
-  description = "Flag for enabling memcache.googleapis.com in your project"
+  description = "Flag for enabling memorystore.googleapis.com in your project"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
2 / 2 Stacked PR.

- add defaults
- set level for fields
- add output for env_vars and apphub_service_uri
- correct errata memcache to memorystore in enable apis
- fix typo between
- fix regex for server_ca_pool


Tested instance creation after ingesting in private catalogue
